### PR TITLE
Allow stock tickers with suffixes and update validation

### DIFF
--- a/src/components/investment/InvestmentFormModal.tsx
+++ b/src/components/investment/InvestmentFormModal.tsx
@@ -90,7 +90,7 @@ export function InvestmentFormModal({
 
         // Validate ticker format
         if (!validateTicker(upperTicker)) {
-          setTickerError('Invalid ticker format (1-5 letters only)');
+          setTickerError('Invalid ticker format. Use letters/numbers with optional . or - separators.');
           setCurrentStockPrice(null);
           return;
         }
@@ -233,9 +233,8 @@ export function InvestmentFormModal({
                     {...register('ticker', {
                       required: assetType === 'stock' ? 'Ticker is required' : false
                     })}
-                    placeholder="e.g., AAPL, TSLA, MSFT"
+                    placeholder="e.g., AAPL, BRK.B, VUN.TO"
                     className="uppercase"
-                    maxLength={5}
                   />
                   {isFetchingPrice && (
                     <div className="absolute right-3 top-1/2 -translate-y-1/2">
@@ -269,7 +268,7 @@ export function InvestmentFormModal({
                     required: assetType === 'stock' ? 'Quantity is required' : false,
                     min: { value: 0.001, message: 'Must be greater than 0' },
                   })}
-                  placeholder="e.g., 100"
+                  placeholder="e.g., 0.009"
                 />
                 {errors.quantity && (
                   <p className="text-sm text-red-500 mt-1">{errors.quantity.message}</p>

--- a/src/lib/services/stockApi.ts
+++ b/src/lib/services/stockApi.ts
@@ -105,8 +105,8 @@ export async function fetchMultipleStockPrices(
  * Validate ticker symbol format
  */
 export function validateTicker(ticker: string): boolean {
-  // Basic validation: 1-5 uppercase letters
-  const tickerRegex = /^[A-Z]{1,5}$/;
+  // Allow 1-5 alphanumeric characters per segment separated by . or - (e.g., BRK.B, VUN.TO)
+  const tickerRegex = /^[A-Z0-9]{1,5}(?:[.-][A-Z0-9]{1,5})*$/;
   return tickerRegex.test(ticker.toUpperCase());
 }
 


### PR DESCRIPTION
## Summary
- relax ticker validation to accept alphanumeric segments separated by dots or hyphens so symbols like VUN.TO pass
- update the investment form placeholder and input limit to support extended tickers without blocking user entry

## Testing
- npm run test
- CI=1 npm run build
- npx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_690311e0ed4c8327845753d968e3fb8d