### PR TITLE
Polish Asset Horizon panel layout for clarity

### DIFF
--- a/src/components/investment/AssetHorizonPanel.tsx
+++ b/src/components/investment/AssetHorizonPanel.tsx
@@ -5,6 +5,7 @@ import { ToolHeader } from '@/components/tools/ToolHeader';
 import { Card } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
 import {
   Select,
   SelectContent,
@@ -36,7 +37,7 @@ import {
   CartesianGrid,
   Legend,
 } from 'recharts';
-import { Rocket, Sparkles } from 'lucide-react';
+import { Sparkles } from 'lucide-react';
 
 interface AssetHorizonPanelProps {
   focusPortfolioId?: string | null;
@@ -253,99 +254,58 @@ export function AssetHorizonPanel({ focusPortfolioId, showHeader = true }: Asset
   };
 
   return (
-    <div className="space-y-6 pb-16">
-      {showHeader && (
+    <div className="space-y-8 pb-16">
+      {showHeader ? (
         <ToolHeader
           title="Asset Horizon"
           emoji="🌅"
-          subtitle="Dial in your future value with playful projections and adventurous scenarios."
-          gradientFrom="from-orange-50 via-amber-50 to-rose-50"
-          borderColor="border-orange-200"
-          textGradient="from-orange-600 via-pink-600 to-fuchsia-600"
+          subtitle="Project future value with recurring contributions and optional boosts."
+          gradientFrom="from-slate-50 via-white to-slate-50"
+          borderColor="border-slate-200"
+          textGradient="from-slate-900 via-slate-700 to-slate-900"
           stats={heroStats.map(stat => ({
             label: stat.label,
             value: stat.value,
             variant: 'info',
           }))}
         />
-      )}
-
-      {!showHeader && (
-        <div className="rounded-xl bg-gradient-to-br from-orange-50 via-amber-50 to-rose-50 border-4 border-orange-200 p-5 shadow-lg">
-          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+      ) : (
+        <Card className="border border-slate-200 bg-white p-6">
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
             <div>
-              <h2 className="text-xl font-semibold text-orange-700 flex items-center gap-2">
-                <span role="img" aria-label="sunrise">🌅</span> Asset Horizon
-              </h2>
-              <p className="text-sm text-orange-700/80">
-                Explore projected growth with recurring contributions and playful scenarios.
+              <h2 className="text-xl font-semibold text-slate-900">🌅 Asset Horizon</h2>
+              <p className="text-sm text-slate-600">
+                Project future value with recurring contributions and optional boosts.
               </p>
             </div>
-            <div className="grid grid-cols-1 sm:grid-cols-3 gap-2 w-full sm:w-auto">
+            <div className="grid w-full grid-cols-1 gap-2 sm:w-auto sm:grid-cols-3">
               {heroStats.map(stat => (
                 <div
                   key={stat.label}
-                  className="rounded-lg border border-orange-100 bg-white/80 px-3 py-2 text-sm text-orange-700"
+                  className="rounded-lg border border-slate-200 bg-white px-3 py-2 text-left text-sm"
                 >
-                  <p className="font-semibold">{stat.value}</p>
-                  <p className="text-xs uppercase tracking-wide">{stat.label}</p>
+                  <p className="font-semibold text-slate-900">{stat.value}</p>
+                  <p className="text-xs uppercase tracking-wide text-slate-500">{stat.label}</p>
                 </div>
               ))}
             </div>
           </div>
-        </div>
+        </Card>
       )}
 
       <div className="grid gap-6 px-4 md:px-0 lg:grid-cols-[1.75fr,1fr]">
-        <Card className="p-6 border border-slate-200/80 bg-white/95 dark:bg-slate-900/80 shadow-sm">
+        <Card className="space-y-6 border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-700 dark:bg-slate-900">
           <div className="grid gap-6 lg:grid-cols-[1.1fr,1fr]">
             <div className="space-y-6">
-              <div className="rounded-2xl border border-slate-200/80 bg-white/80 dark:bg-slate-900/70 p-5">
-                <div className="flex items-center justify-between gap-4">
-                  <div className="flex items-center gap-3">
-                    <div className="p-2 rounded-xl bg-indigo-500/10">
-                      <Sparkles className="w-5 h-5 text-indigo-500" />
-                    </div>
-                    <div>
-                      <p className="text-xs font-medium uppercase tracking-wide text-indigo-600/80">
-                        Expected Annual Return
-                      </p>
-                      <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100">
-                        Adventure Dial
-                      </h2>
-                    </div>
-                  </div>
-                  <div className="rounded-full bg-indigo-50 px-3 py-1 text-sm font-semibold text-indigo-600 dark:bg-indigo-500/10 dark:text-indigo-300">
-                    {returnRate.toFixed(2)}%
-                  </div>
-                </div>
-                <div className="mt-6 space-y-2">
-                  <input
-                    type="range"
-                    min={0}
-                    max={15}
-                    step={0.25}
-                    value={returnRate}
-                    onChange={(event) => setReturnRate(Number(event.target.value))}
-                    className="w-full accent-indigo-500"
-                  />
-                  <div className="flex items-center justify-between text-xs uppercase tracking-wide text-slate-500">
-                    <span>Cautious</span>
-                    <span>Balanced</span>
-                    <span>Bold</span>
-                  </div>
-                </div>
-              </div>
-
               <div className="grid gap-4 sm:grid-cols-2">
-                <div className="rounded-2xl border border-slate-200/80 bg-white/90 p-4 dark:bg-slate-900/70">
+                <div className="rounded-xl border border-slate-200 bg-slate-50/60 p-4 dark:border-slate-700 dark:bg-slate-900/40">
                   <p className="text-xs font-medium uppercase tracking-wide text-slate-500">Current Portfolio</p>
                   <p className="mt-3 text-2xl font-semibold text-slate-900 dark:text-slate-100">
                     {formatCurrency(currentValue, currency)}
                   </p>
-                  <p className="mt-1 text-sm text-slate-500">Today&#39;s balance across tracked assets</p>
+                  <p className="mt-1 text-sm text-slate-500">Balance across tracked accounts</p>
                 </div>
-                <div className="rounded-2xl border border-slate-200/80 bg-white/90 p-4 dark:bg-slate-900/70">
+                <div className="rounded-xl border border-slate-200 bg-slate-50/60 p-4 dark:border-slate-700 dark:bg-slate-900/40">
                   <p className="text-xs font-medium uppercase tracking-wide text-slate-500">Recurring Plan</p>
                   <p className="mt-3 text-2xl font-semibold text-slate-900 dark:text-slate-100">
                     {formatCurrency(baseAmount, currency)}{' '}
@@ -356,33 +316,72 @@ export function AssetHorizonPanel({ focusPortfolioId, showHeader = true }: Asset
                   </p>
                 </div>
               </div>
+
+              <div className="rounded-xl border border-slate-200 bg-slate-50/60 p-5 dark:border-slate-700 dark:bg-slate-900/40">
+                <div className="flex items-center justify-between gap-4">
+                  <div className="flex items-center gap-3">
+                    <div className="flex h-9 w-9 items-center justify-center rounded-full bg-indigo-100 text-indigo-600 dark:bg-indigo-500/10 dark:text-indigo-200">
+                      <Sparkles className="h-4 w-4" />
+                    </div>
+                    <div>
+                      <p className="text-xs font-medium uppercase tracking-wide text-slate-500">Expected annual return</p>
+                      <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100">Assumption</h2>
+                    </div>
+                  </div>
+                  <span className="rounded-full bg-white px-3 py-1 text-sm font-medium text-indigo-600 shadow-sm dark:bg-slate-900">
+                    {returnRate.toFixed(1)}%
+                  </span>
+                </div>
+                <div className="mt-4 space-y-3">
+                  <Label htmlFor="asset-horizon-return" className="text-xs font-medium uppercase tracking-wide text-slate-500">
+                    Tune your expected annual return
+                  </Label>
+                  <input
+                    id="asset-horizon-return"
+                    type="range"
+                    min={0}
+                    max={15}
+                    step={0.25}
+                    value={returnRate}
+                    onChange={(event) => setReturnRate(Number(event.target.value))}
+                    className="w-full accent-indigo-500"
+                  />
+                  <p className="text-xs text-slate-500">
+                    Keep assumptions realistic to reflect how your portfolio might behave over time.
+                  </p>
+                </div>
+              </div>
             </div>
 
-            <div className="space-y-5 rounded-2xl border border-slate-200/80 bg-white/90 p-5 shadow-sm dark:bg-slate-900/70">
-              <h3 className="flex items-center gap-2 text-base font-semibold text-slate-900 dark:text-slate-100">
-                <Rocket className="w-5 h-5 text-indigo-500" />
-                Base Plan Controls
-              </h3>
+            <div className="space-y-5 rounded-xl border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-700 dark:bg-slate-950/60">
+              <div>
+                <h3 className="text-base font-semibold text-slate-900 dark:text-slate-100">Base plan settings</h3>
+                <p className="mt-1 text-sm text-slate-500">
+                  Update the foundation of your projection or link an existing recurring plan.
+                </p>
+              </div>
 
               {planPortfolios.length > 0 && (
                 <div className="space-y-2">
-                  <label className="text-xs font-medium uppercase tracking-wide text-slate-500">
-                    Source Portfolio
-                  </label>
+                  <Label className="text-xs font-medium uppercase tracking-wide text-slate-500" htmlFor="base-plan-source">
+                    Source portfolio
+                  </Label>
                   <Select
-                    value={selectedPlanPortfolioId ?? ''}
-                    onChange={(event) => setSelectedPlanPortfolioId(event.target.value || null)}
+                    id="base-plan-source"
+                    className="h-11 rounded-lg border-slate-200 bg-white px-3 text-left text-sm dark:border-slate-700 dark:bg-slate-900"
+                    value={selectedPlanPortfolioId ?? 'custom'}
+                    onChange={(event) => {
+                      const value = event.target.value;
+                      setSelectedPlanPortfolioId(value === 'custom' ? null : value);
+                    }}
                   >
-                    <SelectTrigger className="h-11 rounded-xl border-slate-200 bg-white/90 text-left text-sm dark:border-slate-700 dark:bg-slate-950/60">
-                      <SelectValue placeholder="Select a plan" />
-                    </SelectTrigger>
                     <SelectContent>
                       {planPortfolios.map(portfolio => (
                         <SelectItem key={portfolio.id} value={portfolio.id}>
                           {portfolio.name}
                         </SelectItem>
                       ))}
-                      <SelectItem value="">Custom plan (manual)</SelectItem>
+                      <SelectItem value="custom">Custom plan (manual)</SelectItem>
                     </SelectContent>
                   </Select>
                 </div>
@@ -390,25 +389,29 @@ export function AssetHorizonPanel({ focusPortfolioId, showHeader = true }: Asset
 
               <div className="grid gap-4 sm:grid-cols-2">
                 <div className="space-y-2">
-                  <label className="text-xs font-medium uppercase tracking-wide text-slate-500">Recurring Amount</label>
+                  <Label className="text-xs font-medium uppercase tracking-wide text-slate-500" htmlFor="base-plan-amount">
+                    Recurring amount
+                  </Label>
                   <Input
+                    id="base-plan-amount"
                     type="number"
                     min={0}
-                    step={50}
+                    step={25}
                     value={baseAmount}
                     onChange={(event) => setBaseAmount(Math.max(0, Number(event.target.value)))}
-                    className="h-11 rounded-xl border-slate-200 bg-white/90 text-base dark:border-slate-700 dark:bg-slate-950/60"
+                    className="h-11 rounded-lg border-slate-200 bg-white text-base dark:border-slate-700 dark:bg-slate-900"
                   />
                 </div>
                 <div className="space-y-2">
-                  <label className="text-xs font-medium uppercase tracking-wide text-slate-500">Frequency</label>
+                  <Label className="text-xs font-medium uppercase tracking-wide text-slate-500" htmlFor="base-plan-frequency">
+                    Frequency
+                  </Label>
                   <Select
+                    id="base-plan-frequency"
+                    className="h-11 rounded-lg border-slate-200 bg-white px-3 text-left text-sm dark:border-slate-700 dark:bg-slate-900"
                     value={baseFrequency}
                     onChange={(event) => setBaseFrequency(event.target.value as RecurringFrequency)}
                   >
-                    <SelectTrigger className="h-11 rounded-xl border-slate-200 bg-white/90 text-left text-sm dark:border-slate-700 dark:bg-slate-950/60">
-                      <SelectValue placeholder="Select frequency" />
-                    </SelectTrigger>
                     <SelectContent>
                       <SelectItem value="monthly">Monthly</SelectItem>
                       <SelectItem value="biweekly">Bi-weekly</SelectItem>
@@ -422,8 +425,8 @@ export function AssetHorizonPanel({ focusPortfolioId, showHeader = true }: Asset
             </div>
           </div>
 
-          <div className="mt-8 space-y-6">
-            <div className="rounded-2xl border border-slate-200/80 bg-white/90 p-5 dark:bg-slate-900/70">
+          <div className="space-y-6">
+            <div className="rounded-xl border border-slate-200 bg-white p-5 dark:border-slate-700 dark:bg-slate-950/60">
               <ResponsiveContainer width="100%" height={320}>
                 <LineChart data={chartData}>
                   <CartesianGrid strokeDasharray="4 4" stroke="#e2e8f0" />
@@ -433,18 +436,15 @@ export function AssetHorizonPanel({ focusPortfolioId, showHeader = true }: Asset
                     tick={{ fontSize: 12 }}
                     stroke="#94a3b8"
                   />
-                  <Tooltip
-                    formatter={(value: number) => formatCurrency(value, currency)}
-                    labelClassName="text-sm font-semibold text-indigo-600"
-                  />
+                  <Tooltip formatter={(value: number) => formatCurrency(value, currency)} />
                   <Legend />
                   <Line
                     type="monotone"
                     dataKey="base"
-                    stroke="#10b981"
+                    stroke="#0ea5e9"
                     strokeWidth={3}
                     dot={false}
-                    name="Base Plan"
+                    name="Base plan"
                   />
                   {scenarioSeries.map(({ scenario }) => (
                     <Line
@@ -463,15 +463,12 @@ export function AssetHorizonPanel({ focusPortfolioId, showHeader = true }: Asset
 
             <div className="grid gap-4 sm:grid-cols-3">
               {heroStats.map(stat => (
-                <div
-                  key={stat.label}
-                  className="rounded-2xl border border-slate-200/80 bg-white/90 p-4 text-left shadow-sm dark:bg-slate-900/70"
-                >
+                <div key={stat.label} className="rounded-xl border border-slate-200 bg-white p-4 dark:border-slate-700 dark:bg-slate-950/60">
                   <p className="text-xs font-medium uppercase tracking-wide text-slate-500">{stat.label}</p>
                   <p className="mt-2 text-xl font-semibold text-slate-900 dark:text-slate-100">{stat.value}</p>
                   <p className="text-xs text-slate-500">
                     {stat.delta >= 0 ? '+' : ''}
-                    {stat.change} growth from today
+                    {stat.change} from today
                   </p>
                 </div>
               ))}
@@ -479,25 +476,25 @@ export function AssetHorizonPanel({ focusPortfolioId, showHeader = true }: Asset
           </div>
         </Card>
 
-        <Card className="flex h-full flex-col gap-6 rounded-3xl border border-slate-200/80 bg-white/95 p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900/80">
-          <div className="space-y-2">
-            <p className="text-xs font-medium uppercase tracking-wide text-indigo-600/90">What-if Labs</p>
-            <h3 className="text-lg font-semibold text-slate-900 dark:text-slate-100">Hypothetical Boosts</h3>
+        <Card className="flex h-full flex-col gap-5 border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-700 dark:bg-slate-900">
+          <div className="space-y-1">
+            <p className="text-xs font-medium uppercase tracking-wide text-slate-500">Scenarios</p>
+            <h3 className="text-lg font-semibold text-slate-900 dark:text-slate-100">Layer extra contributions</h3>
             <p className="text-sm text-slate-500">
-              Layer extra plans to understand how additional contributions reshape your horizon.
+              Compare additional boosts alongside your base plan to see how outcomes shift.
             </p>
           </div>
           <Button
             onClick={addScenario}
-            className="h-11 rounded-xl bg-indigo-500 text-sm font-semibold text-white transition hover:bg-indigo-600"
+            className="h-11 rounded-lg bg-slate-900 text-sm font-semibold text-white hover:bg-slate-800 dark:bg-slate-100 dark:text-slate-900 dark:hover:bg-white"
           >
-            Add Scenario
+            Add scenario
           </Button>
 
           <div className="space-y-4">
             {scenarios.length === 0 ? (
-              <div className="rounded-2xl border border-dashed border-slate-200/80 bg-white/80 p-5 text-sm text-slate-500 dark:border-slate-700 dark:bg-slate-900/60">
-                No scenarios yet. Tap &quot;Add Scenario&quot; to design a boost plan.
+              <div className="rounded-lg border border-dashed border-slate-300 bg-slate-50/70 p-5 text-sm text-slate-500 dark:border-slate-700 dark:bg-slate-900/40">
+                No scenarios yet. Start by adding a boost plan to compare results.
               </div>
             ) : (
               scenarios.map((scenario, index) => {
@@ -511,7 +508,7 @@ export function AssetHorizonPanel({ focusPortfolioId, showHeader = true }: Asset
                 return (
                   <div
                     key={scenario.id}
-                    className="space-y-4 rounded-2xl border border-slate-200/80 bg-white/90 p-5 shadow-sm transition hover:border-indigo-200 dark:bg-slate-900/70"
+                    className="space-y-4 rounded-lg border border-slate-200 bg-white p-5 shadow-sm transition hover:border-slate-400 dark:border-slate-700 dark:bg-slate-950/60"
                   >
                     <div className="flex items-center justify-between gap-3">
                       <div>
@@ -529,37 +526,46 @@ export function AssetHorizonPanel({ focusPortfolioId, showHeader = true }: Asset
 
                     <div className="grid gap-4 sm:grid-cols-2">
                       <div className="space-y-1">
-                        <label className="text-xs font-medium uppercase tracking-wide text-slate-500">Label</label>
+                        <Label className="text-xs font-medium uppercase tracking-wide text-slate-500" htmlFor={`scenario-label-${scenario.id}`}>
+                          Label
+                        </Label>
                         <Input
+                          id={`scenario-label-${scenario.id}`}
                           value={scenario.label}
                           onChange={(event) => updateScenario(scenario.id, { label: event.target.value })}
-                          className="h-11 rounded-xl border-slate-200 bg-white/90 text-sm dark:border-slate-700 dark:bg-slate-950/60"
+                          className="h-11 rounded-lg border-slate-200 bg-white text-sm dark:border-slate-700 dark:bg-slate-900"
                         />
                       </div>
                       <div className="space-y-1">
-                        <label className="text-xs font-medium uppercase tracking-wide text-slate-500">Amount</label>
+                        <Label className="text-xs font-medium uppercase tracking-wide text-slate-500" htmlFor={`scenario-amount-${scenario.id}`}>
+                          Amount
+                        </Label>
                         <Input
+                          id={`scenario-amount-${scenario.id}`}
                           type="number"
                           min={0}
-                          step={50}
+                          step={25}
                           value={scenario.amount}
                           onChange={(event) =>
                             updateScenario(scenario.id, { amount: Math.max(0, Number(event.target.value)) })
                           }
-                          className="h-11 rounded-xl border-slate-200 bg-white/90 text-sm dark:border-slate-700 dark:bg-slate-950/60"
+                          className="h-11 rounded-lg border-slate-200 bg-white text-sm dark:border-slate-700 dark:bg-slate-900"
                         />
                       </div>
                       <div className="space-y-1">
-                        <label className="text-xs font-medium uppercase tracking-wide text-slate-500">Frequency</label>
+                        <Label className="text-xs font-medium uppercase tracking-wide text-slate-500" htmlFor={`scenario-frequency-${scenario.id}`}>
+                          Frequency
+                        </Label>
                         <Select
+                          id={`scenario-frequency-${scenario.id}`}
+                          className="h-11 rounded-lg border-slate-200 bg-white px-3 text-left text-sm dark:border-slate-700 dark:bg-slate-900"
                           value={scenario.frequency}
                           onChange={(event) =>
-                            updateScenario(scenario.id, { frequency: event.target.value as RecurringFrequency })
+                            updateScenario(scenario.id, {
+                              frequency: event.target.value as RecurringFrequency,
+                            })
                           }
                         >
-                          <SelectTrigger className="h-11 rounded-xl border-slate-200 bg-white/90 text-left text-sm dark:border-slate-700 dark:bg-slate-950/60">
-                            <SelectValue placeholder="Select frequency" />
-                          </SelectTrigger>
                           <SelectContent>
                             <SelectItem value="monthly">Monthly</SelectItem>
                             <SelectItem value="biweekly">Bi-weekly</SelectItem>
@@ -570,13 +576,13 @@ export function AssetHorizonPanel({ focusPortfolioId, showHeader = true }: Asset
                         </Select>
                       </div>
                       <div className="flex items-end justify-between gap-2">
-                        <div className="rounded-xl bg-indigo-50 px-3 py-2 text-sm font-medium text-indigo-600 dark:bg-indigo-500/10 dark:text-indigo-300">
+                        <div className="rounded-md bg-slate-100 px-3 py-2 text-sm font-medium text-slate-700 dark:bg-slate-800 dark:text-slate-200">
                           {delta >= 0 ? '+' : ''}{formatCurrency(delta, currency)} at 15Y
                         </div>
                         <Button
                           variant="outline"
                           onClick={() => removeScenario(scenario.id)}
-                          className="h-10 rounded-xl border-slate-200 text-sm font-medium text-slate-600 hover:border-red-200 hover:bg-red-50 hover:text-red-600 dark:border-slate-700 dark:text-slate-300 dark:hover:border-red-300 dark:hover:bg-red-500/10"
+                          className="h-10 rounded-lg border-slate-200 text-sm font-medium text-slate-600 hover:border-red-200 hover:bg-red-50 hover:text-red-600 dark:border-slate-700 dark:text-slate-300 dark:hover:border-red-400 dark:hover:bg-red-500/10"
                         >
                           Remove
                         </Button>


### PR DESCRIPTION
## Summary
- refresh the Asset Horizon panel with lighter borders, softer gradients, and clearer spacing
- streamline the base plan controls and scenario editor styling for a calmer, more readable layout

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_6905310491708327be42c26252a03ce3