### PR TITLE
Fix home page infinite loading issue

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -19,7 +19,7 @@ export const dynamic = 'force-dynamic';
 type FormValues = { text: string };
 
 export default function Page() {
-  const { user, isAnonymous } = useAuth();
+  const { user, isAnonymous, loading: authLoading } = useAuth();
   const { register, handleSubmit, reset } = useForm<FormValues>();
   // Thoughts store
   const thoughts = useThoughts((s) => s.thoughts);
@@ -46,7 +46,8 @@ export default function Page() {
   const tasksSubscribed = useTasks((s) => s.isSubscribed);
 
   // Only show loading if subscriptions are active and still loading (without cache data yet)
-  const isInitialLoading = (thoughtsLoading && !thoughtsFromCache) || (tasksLoading && !tasksFromCache);
+  // AND auth has finished loading and user exists
+  const isInitialLoading = !authLoading && user && ((thoughtsLoading && !thoughtsFromCache) || (tasksLoading && !tasksFromCache));
   const hasSyncError = thoughtsSyncError || tasksSyncError;
   const subscriptionsActive = thoughtsSubscribed || tasksSubscribed;
 


### PR DESCRIPTION
…users

The home page was showing an infinite loading spinner when users weren't logged in because it was checking the initial loading state of the data stores without verifying if a user exists.

Changes:
- Add authLoading state from useAuth hook
- Update isInitialLoading to only be true when auth has finished loading AND a user exists AND data is loading
- This ensures non-logged-in users see the home page content immediately instead of being stuck on a loading spinner

Fixes the issue where the page keeps loading while the user is not logged in.