### PR TITLE
Fix location is not defined error in billing page

### DIFF
--- a/src/app/billing/page.tsx
+++ b/src/app/billing/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { httpsCallable } from 'firebase/functions';
 import { functionsClient } from '@/lib/firebaseClient';
@@ -42,11 +42,12 @@ export default function BillingPage() {
   const [showReactivateDialog, setShowReactivateDialog] = useState(false);
   const [isReactivating, setIsReactivating] = useState(false);
 
-  // Redirect if not logged in
-  if (!user && !subscriptionLoading) {
-    router.push('/profile');
-    return null;
-  }
+  // Redirect if not logged in (client-side only)
+  useEffect(() => {
+    if (!user && !subscriptionLoading) {
+      router.push('/profile');
+    }
+  }, [user, subscriptionLoading, router]);
 
   const handleManageBilling = async () => {
     try {


### PR DESCRIPTION
Move router.push redirect to useEffect to prevent accessing location during server-side rendering. The redirect now only runs on the client side, eliminating the ReferenceError: location is not defined error.

Fixes issue where router.push was called during render phase, causing Next.js to attempt accessing the browser's location API during SSR.