### PR TITLE
Disable screenshot tests for main branch

### DIFF
--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -3,18 +3,10 @@ name: Screenshot Tests
 # Visual regression testing with Firebase Local Emulator Suite
 # - Installs Java for Firebase emulators (real Firebase SDK behavior)
 # - Falls back to mocked Firebase if Java unavailable (still works!)
-# - Runs on PRs with relevant file changes only
+# - Only runs on release tags (v*) and manual workflow dispatch
+# - Disabled for PRs and regular pushes to reduce CI time
 
 on:
-  pull_request:
-    branches: [main, develop]
-    paths:
-      - 'src/**'
-      - 'app/**'
-      - 'components/**'
-      - 'e2e/**'
-      - 'package*.json'
-      - 'playwright.config.ts'
   push:
     tags:
       - 'v*'


### PR DESCRIPTION
- Screenshot tests now only run on release tags (v*) and manual workflow dispatch
- Removed pull_request trigger to reduce CI overhead
- Tests will still run for releases to ensure production quality
- Updated comments to reflect new behavior