### PR TITLE
Fix RichTextEditor displaying raw text on Goal page

### DIFF
--- a/src/app/tools/projects/[id]/page.tsx
+++ b/src/app/tools/projects/[id]/page.tsx
@@ -539,7 +539,9 @@ export default function ProjectDetailPage() {
                     <div className="font-bold text-purple-700 dark:text-purple-300 text-lg group-hover:text-purple-800 dark:group-hover:text-purple-200 transition-colors">
                       {linkedGoal.title}
                     </div>
-                    <div className="text-sm text-gray-600 dark:text-gray-400 mt-1">{linkedGoal.objective}</div>
+                    <div className="text-sm text-gray-600 dark:text-gray-400 mt-1 prose prose-sm dark:prose-invert max-w-none">
+                      <div dangerouslySetInnerHTML={{ __html: linkedGoal.objective }} />
+                    </div>
                   </div>
                   <div className="text-purple-400 dark:text-purple-500 group-hover:text-purple-600 dark:group-hover:text-purple-400 transition-colors">
                     <Flag className="h-5 w-5" />

--- a/src/components/ThoughtDetailModal.tsx
+++ b/src/components/ThoughtDetailModal.tsx
@@ -964,8 +964,8 @@ export function ThoughtDetailModal({ thought, onClose }: ThoughtDetailModalProps
                                   {project.title}
                                 </div>
                                 {project.objective && (
-                                  <div className="text-xs text-gray-600 dark:text-gray-400 mt-1 line-clamp-1">
-                                    {project.objective}
+                                  <div className="text-xs text-gray-600 dark:text-gray-400 mt-1 line-clamp-1 prose prose-xs dark:prose-invert max-w-none">
+                                    <div dangerouslySetInnerHTML={{ __html: project.objective }} />
                                   </div>
                                 )}
                               </Link>
@@ -1057,8 +1057,8 @@ export function ThoughtDetailModal({ thought, onClose }: ThoughtDetailModalProps
                                   {goal.title}
                                 </div>
                                 {goal.objective && (
-                                  <div className="text-xs text-gray-600 dark:text-gray-400 mt-1 line-clamp-1">
-                                    {goal.objective}
+                                  <div className="text-xs text-gray-600 dark:text-gray-400 mt-1 line-clamp-1 prose prose-xs dark:prose-invert max-w-none">
+                                    <div dangerouslySetInnerHTML={{ __html: goal.objective }} />
                                   </div>
                                 )}
                               </Link>
@@ -1115,8 +1115,8 @@ export function ThoughtDetailModal({ thought, onClose }: ThoughtDetailModalProps
                                   {project.title}
                                 </div>
                                 {project.objective && (
-                                  <div className="text-xs text-gray-600 dark:text-gray-400 mt-1 line-clamp-1">
-                                    {project.objective}
+                                  <div className="text-xs text-gray-600 dark:text-gray-400 mt-1 line-clamp-1 prose prose-xs dark:prose-invert max-w-none">
+                                    <div dangerouslySetInnerHTML={{ __html: project.objective }} />
                                   </div>
                                 )}
                               </Link>

--- a/src/components/goal/GoalProjectLinks.tsx
+++ b/src/components/goal/GoalProjectLinks.tsx
@@ -108,7 +108,9 @@ export function GoalProjectLinks({
                       {project.title}
                     </div>
                     {project.objective && (
-                      <div className="text-sm text-gray-600 dark:text-gray-400 mt-1">{project.objective}</div>
+                      <div className="text-sm text-gray-600 dark:text-gray-400 mt-1 prose prose-sm dark:prose-invert max-w-none">
+                        <div dangerouslySetInnerHTML={{ __html: project.objective }} />
+                      </div>
                     )}
                     <div className="flex items-center gap-2 mt-2">
                       <span className={`px-2 py-1 rounded-full text-xs font-medium ${
@@ -197,7 +199,9 @@ export function GoalProjectLinks({
                           {project.title}
                         </div>
                         {project.objective && (
-                          <div className="text-sm text-gray-600 dark:text-gray-400 mt-1">{project.objective}</div>
+                          <div className="text-sm text-gray-600 dark:text-gray-400 mt-1 prose prose-sm dark:prose-invert max-w-none">
+                            <div dangerouslySetInnerHTML={{ __html: project.objective }} />
+                          </div>
                         )}
                       </div>
                     </div>


### PR DESCRIPTION
Fixed 6 instances where goal and project objectives were displaying raw HTML instead of rendered rich text:
- ThoughtDetailModal.tsx: 3 instances (project and goal objectives)
- Project detail page: 1 instance (linked goal objective)
- GoalProjectLinks.tsx: 2 instances (project objectives in list and modal)

All instances now use dangerouslySetInnerHTML with prose styling for proper rich text rendering.