### PR TITLE
Fix GitHub Actions permission error on issue comments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ on:
 
 permissions:
   contents: read
-  pull-requests: read
+  pull-requests: write
   issues: write
 
 jobs:


### PR DESCRIPTION
The github-script actions in the CI workflow need pull-requests: write permission to create comments on PRs. Previously set to read-only, causing 403 errors when attempting to post deployment status comments.

Fixes the "Resource not accessible by integration" error in workflow runs.