### PR TITLE
refactor: extract hardcoded prompts to YAML configuration files

### DIFF
--- a/functions/prompts/categorize-transaction.prompt.yml
+++ b/functions/prompts/categorize-transaction.prompt.yml
@@ -1,0 +1,119 @@
+name: Categorize Transaction
+description: Categorizes individual bank transactions into hierarchical categories with subcategories and confidence scores
+
+model: anthropic/claude-3-5-haiku-20241022
+
+modelParameters:
+  temperature: 0
+  max_tokens: 150
+
+messages:
+  - role: user
+    content: |
+      Categorize this transaction into one of the premium categories:
+
+      Merchant: {{merchant}}
+      Description: {{description}}
+      Amount: ${{amount}}
+
+      Categories:
+      - Food & Drink (subcategories: Cafe, Casual Dining, Fine Dining, Groceries, Fast Food, Alcohol & Bars)
+      - Transport (subcategories: Ridehail, Public Transit, Fuel, Parking, Auto Maintenance)
+      - Shopping (subcategories: Clothes, Electronics, Home Décor, General, Online Shopping)
+      - Travel (subcategories: Flights, Hotels, Airbnb, Tours, Car Rental)
+      - Entertainment
+      - Fitness
+      - Wellness
+      - Utilities
+      - Rent/Mortgage
+      - Fees/Interest
+      - Income
+      - Education
+      - Other
+
+      Return ONLY a JSON object with this exact format:
+      {
+        "level1": "category name",
+        "level2": "subcategory name or null",
+        "confidence": 0.85
+      }
+
+testData:
+  - merchant: "Starbucks"
+    description: "STARBUCKS STORE #12345 SAN FRANCISCO CA"
+    amount: "8.75"
+    expected: |
+      {
+        "level1": "Food & Drink",
+        "level2": "Cafe",
+        "confidence": 0.98
+      }
+
+  - merchant: "Shell"
+    description: "SHELL OIL 57452935 SAN FRANCISCO CA"
+    amount: "52.00"
+    expected: |
+      {
+        "level1": "Transport",
+        "level2": "Fuel",
+        "confidence": 0.95
+      }
+
+  - merchant: "Amazon"
+    description: "AMZN Mktp US*2X4Y8Z Seattle WA"
+    amount: "45.32"
+    expected: |
+      {
+        "level1": "Shopping",
+        "level2": "Online Shopping",
+        "confidence": 0.90
+      }
+
+  - merchant: "Delta Airlines"
+    description: "DELTA AIR 00623456789 ATLANTA GA"
+    amount: "450.00"
+    expected: |
+      {
+        "level1": "Travel",
+        "level2": "Flights",
+        "confidence": 0.99
+      }
+
+  - merchant: "LA Fitness"
+    description: "LA FITNESS #0234 MEMBERSHIP"
+    amount: "45.00"
+    expected: |
+      {
+        "level1": "Fitness",
+        "level2": null,
+        "confidence": 0.97
+      }
+
+evaluators:
+  - name: Response is valid JSON
+    string:
+      matchesRegex: '^\{.*\}$'
+
+  - name: Contains level1 field
+    string:
+      contains: '"level1":'
+
+  - name: Contains level2 field
+    string:
+      contains: '"level2":'
+
+  - name: Contains confidence field
+    string:
+      contains: '"confidence":'
+
+  - name: level1 is from allowed categories
+    string:
+      matchesRegex: '"level1":\s*"(Food & Drink|Transport|Shopping|Travel|Entertainment|Fitness|Wellness|Utilities|Rent/Mortgage|Fees/Interest|Income|Education|Other)"'
+
+  - name: confidence is numeric 0-1
+    string:
+      matchesRegex: '"confidence":\s*(0(\.\d+)?|1(\.0+)?)'
+
+  - name: level2 is string or null
+    string:
+      matchesRegex: '"level2":\s*("[\w\s&]+"|null)'

--- a/functions/prompts/enhance-visa-requirements.prompt.yml
+++ b/functions/prompts/enhance-visa-requirements.prompt.yml
@@ -1,0 +1,129 @@
+name: Enhance Visa Requirements
+description: Generates comprehensive visa requirement information for citizens of a source country traveling to destination countries in batches
+
+model: openai/gpt-4o-mini
+
+modelParameters:
+  temperature: 0.3
+  max_tokens: 16384
+
+messages:
+  - role: system
+    content: |
+      You are a visa requirements expert. Always respond with valid JSON only. Be accurate and concise.
+
+  - role: user
+    content: |
+      You are a visa requirements expert. Provide accurate visa requirements for citizens of {{sourceCountryName}} ({{sourceCountryCode}}) traveling to the following countries.
+
+      For each destination, provide:
+      1. Visa type: "visa-free", "e-visa", "visa-on-arrival", or "visa-required"
+      2. Duration allowed (e.g., "90 days", "30 days", "N/A" for visa-required)
+      3. Brief description (25-35 words highlighting key attractions, culture, or features)
+      4. Region (use: "Africa", "Asia", "Europe", "North America", "South America", or "Oceania")
+      5. Basic requirements (e.g., ["Valid passport", "Return ticket"])
+
+      Destinations: {{destinations}}
+
+      IMPORTANT: Respond ONLY with valid JSON. No additional text.
+
+      JSON format:
+      {
+        "destinations": [
+          {
+            "countryCode": "JP",
+            "countryName": "Japan",
+            "visaType": "visa-free",
+            "duration": "90 days",
+            "description": "Island nation known for cherry blossoms, ancient temples, cutting-edge technology, anime culture, hot springs, and world-class cuisine including sushi and ramen.",
+            "region": "Asia",
+            "requirements": ["Valid passport with 6 months validity", "Return or onward ticket", "Proof of sufficient funds"],
+            "notes": "For tourism, business, or visiting friends/family"
+          }
+        ]
+      }
+
+testData:
+  - sourceCountryName: "United States"
+    sourceCountryCode: "US"
+    destinations: "Japan (JP), United Kingdom (GB), Thailand (TH)"
+    expected: |
+      {
+        "destinations": [
+          {
+            "countryCode": "JP",
+            "countryName": "Japan",
+            "visaType": "visa-free",
+            "duration": "90 days",
+            "description": "Island nation known for cherry blossoms, ancient temples, cutting-edge technology, anime culture, hot springs, and world-class cuisine including sushi and ramen.",
+            "region": "Asia",
+            "requirements": ["Valid passport with 6 months validity", "Return or onward ticket", "Proof of sufficient funds"],
+            "notes": "For tourism, business, or visiting friends/family"
+          },
+          {
+            "countryCode": "GB",
+            "countryName": "United Kingdom",
+            "visaType": "visa-free",
+            "duration": "180 days",
+            "description": "Historic kingdom featuring royal palaces, iconic landmarks like Big Ben, diverse culture, world-class museums, beautiful countryside, and rich literary heritage.",
+            "region": "Europe",
+            "requirements": ["Valid passport for duration of stay", "Proof of accommodation", "Return ticket"],
+            "notes": "For tourism and short business trips"
+          },
+          {
+            "countryCode": "TH",
+            "countryName": "Thailand",
+            "visaType": "visa-free",
+            "duration": "30 days",
+            "description": "Southeast Asian destination famous for tropical beaches, ornate temples, vibrant street food, bustling Bangkok, elephant sanctuaries, and warm hospitality.",
+            "region": "Asia",
+            "requirements": ["Valid passport with 6 months validity", "Proof of onward travel", "Proof of accommodation"],
+            "notes": "Can be extended for 30 more days at immigration office"
+          }
+        ]
+      }
+
+evaluators:
+  - name: Response is valid JSON
+    string:
+      matchesRegex: '^\{.*\}$'
+
+  - name: Contains destinations array
+    string:
+      contains: '"destinations":'
+
+  - name: Has countryCode field
+    string:
+      contains: '"countryCode":'
+
+  - name: Has countryName field
+    string:
+      contains: '"countryName":'
+
+  - name: Has visaType field
+    string:
+      contains: '"visaType":'
+
+  - name: Has duration field
+    string:
+      contains: '"duration":'
+
+  - name: Has description field
+    string:
+      contains: '"description":'
+
+  - name: Has region field
+    string:
+      contains: '"region":'
+
+  - name: Has requirements array
+    string:
+      contains: '"requirements":'
+
+  - name: visaType values are valid
+    string:
+      matchesRegex: '"visaType":\s*"(visa-free|e-visa|visa-on-arrival|visa-required)"'
+
+  - name: region values are valid
+    string:
+      matchesRegex: '"region":\s*"(Africa|Asia|Europe|North America|South America|Oceania)"'

--- a/functions/prompts/generate-spending-insights.prompt.yml
+++ b/functions/prompts/generate-spending-insights.prompt.yml
@@ -1,0 +1,171 @@
+name: Generate Spending Insights
+description: Analyzes monthly spending data to generate actionable insights, warnings, subscription detection, budget suggestions, and clarifying questions
+
+model: anthropic/claude-3-5-sonnet-20241022
+
+modelParameters:
+  temperature: 0
+  max_tokens: 2000
+
+messages:
+  - role: system
+    content: |
+      You are a precise personal-finance analyst. Use only provided aggregates and notable transactions.
+      Do not invent numbers. If data is missing, state what's missing.
+      Produce 3–6 headlineInsights; spendWarnings for categories with >30% MoM increase; list newSubscriptions exactly as provided; suggest 2–4 actionable budgetSuggestions; ask 1–3 clarifying questions.
+      Return valid JSON only conforming to the schema.
+
+  - role: user
+    content: |
+      Analyze this spending data for {{month}}:
+
+      ## Summary
+      - Total Outflow: ${{outflow}}
+      - Total Inflow: ${{inflow}}
+      - Net Cashflow: ${{netCashflow}}
+      - Transaction Count: {{transactionCount}}
+
+      ## Category Breakdown
+      {{categoryBreakdown}}
+
+      ## Top Merchants
+      {{topMerchants}}
+
+      ## Anomalies (vs Previous Month)
+      {{anomalies}}
+
+      ## Notable Transactions
+      {{notableTransactions}}
+
+      Return a JSON object with this exact structure:
+      {
+        "month": "YYYY-MM",
+        "headlineInsights": ["string", "string", ...],
+        "spendWarnings": [{"category": "string", "deltaPct": number, "explanation": "string"}, ...],
+        "newSubscriptions": [{"merchant": "string", "amount": number, "firstSeen": "YYYY-MM-DD"}, ...],
+        "budgetSuggestions": {
+          "notes": "string",
+          "actions": [{"title": "string", "impact": "string"}, ...]
+        },
+        "questionsForUser": ["string", ...]
+      }
+
+testData:
+  - month: "2025-11"
+    outflow: "3542.75"
+    inflow: "5200.00"
+    netCashflow: "1657.25"
+    transactionCount: "142"
+    categoryBreakdown: |
+      - Food & Drink: $892.50 (25.2%, 45 txns)
+      - Transport: $456.30 (12.9%, 18 txns)
+      - Shopping: $678.90 (19.2%, 23 txns)
+      - Entertainment: $234.50 (6.6%, 12 txns)
+      - Utilities: $425.00 (12.0%, 8 txns)
+      - Fitness: $185.00 (5.2%, 6 txns)
+      - Other: $670.55 (18.9%, 30 txns)
+    topMerchants: |
+      - Whole Foods: $342.80 (12 txns)
+      - Shell: $245.60 (8 txns)
+      - Amazon: $567.90 (15 txns)
+      - Netflix: $15.99 (1 txns)
+      - Spotify: $10.99 (1 txns)
+      - LA Fitness: $45.00 (1 txns)
+      - Starbucks: $156.40 (18 txns)
+    anomalies: |
+      - Shopping: +42% Significant increase in online shopping
+      - Entertainment: +15% Slight increase in entertainment spending
+    notableTransactions: |
+      - Amazon: $234.50 on 2025-11-05 (Shopping)
+      - Whole Foods: $125.80 on 2025-11-12 (Food & Drink)
+      - Shell: $65.00 on 2025-11-08 (Transport)
+      - Apple Store: $299.00 on 2025-11-15 (Shopping)
+    expected: |
+      {
+        "month": "2025-11",
+        "headlineInsights": [
+          "Net positive cashflow of $1,657.25 this month",
+          "Food & Drink is your largest category at 25.2% of spending",
+          "Shopping spending increased by 42% compared to last month",
+          "You're averaging $24.95 per day in spending",
+          "Three active subscriptions detected: Netflix, Spotify, LA Fitness"
+        ],
+        "spendWarnings": [
+          {
+            "category": "Shopping",
+            "deltaPct": 42,
+            "explanation": "Significant increase driven by Amazon and Apple Store purchases"
+          }
+        ],
+        "newSubscriptions": [
+          {
+            "merchant": "Netflix",
+            "amount": 15.99,
+            "firstSeen": "2025-11-01"
+          },
+          {
+            "merchant": "Spotify",
+            "amount": 10.99,
+            "firstSeen": "2025-11-01"
+          }
+        ],
+        "budgetSuggestions": {
+          "notes": "Consider reducing discretionary spending in shopping and coffee purchases",
+          "actions": [
+            {
+              "title": "Set a monthly shopping budget of $500",
+              "impact": "Could save ~$179 per month"
+            },
+            {
+              "title": "Reduce Starbucks visits to 2-3 times per week",
+              "impact": "Could save ~$100 per month"
+            },
+            {
+              "title": "Review and consolidate streaming subscriptions",
+              "impact": "Potential savings of $10-20 per month"
+            }
+          ]
+        },
+        "questionsForUser": [
+          "Was the Apple Store purchase planned or impulse?",
+          "Are you using all your active subscriptions regularly?",
+          "Would you like to set spending limits for specific categories?"
+        ]
+      }
+
+evaluators:
+  - name: Response is valid JSON
+    string:
+      matchesRegex: '^\{.*\}$'
+
+  - name: Contains month field
+    string:
+      contains: '"month":'
+
+  - name: Contains headlineInsights array
+    string:
+      contains: '"headlineInsights":'
+
+  - name: Contains spendWarnings array
+    string:
+      contains: '"spendWarnings":'
+
+  - name: Contains newSubscriptions array
+    string:
+      contains: '"newSubscriptions":'
+
+  - name: Contains budgetSuggestions object
+    string:
+      contains: '"budgetSuggestions":'
+
+  - name: Contains questionsForUser array
+    string:
+      contains: '"questionsForUser":'
+
+  - name: budgetSuggestions has notes and actions
+    string:
+      matchesRegex: '"budgetSuggestions":\s*\{[^}]*"notes":[^}]*"actions":'
+
+  - name: spendWarnings have required fields
+    string:
+      matchesRegex: '"spendWarnings":\s*\[[^\]]*("category"|"deltaPct"|"explanation")'

--- a/functions/prompts/trip-linking.prompt.yml
+++ b/functions/prompts/trip-linking.prompt.yml
@@ -1,0 +1,119 @@
+name: Trip-Transaction Linking
+description: Matches bank transactions to user trips based on currency, timing, and merchant/location signals with confidence-based linking decisions
+
+model: anthropic/claude-3-5-sonnet-20241022
+
+modelParameters:
+  temperature: 0
+  max_tokens: 1500
+
+messages:
+  - role: user
+    content: |
+      You match bank transactions to user trips. Only link a transaction to a trip when currency, timing, and merchant/location strongly indicate they belong together.
+      Return structured JSON and never invent trips.
+
+      Trips:
+      {{tripBlock}}
+
+      Transactions:
+      {{transactionBlock}}
+
+      For each transaction respond with JSON matching:
+      {
+        "results": [
+          {
+            "transactionId": "",
+            "decision": "link" | "suggest" | "skip",
+            "tripId": "trip-id-or-null",
+            "confidence": 0.0-1.0,
+            "reasoning": "string"
+          }
+        ]
+      }
+      Rules:
+      - Use "link" only when confidence >= 0.8.
+      - Use "suggest" for confidence between 0.6 and 0.79.
+      - Otherwise "skip" with null tripId.
+      - Confidence must be numeric 0-1.
+      - Each transaction appears exactly once.
+
+testData:
+  - tripBlock: |
+      - [trip-1] Tokyo Adventure (Japan) from 2025-11-01 to 2025-11-10 in JPY
+      - [trip-2] Paris Vacation (France) from 2025-11-15 to 2025-11-22 in EUR
+    transactionBlock: |
+      - [txn-1] 2025-11-03 • JPY 5000.00 @ Lawson Convenience Store | location: Tokyo, Kanto, Japan | LAWSON SHIBUYA
+      - [txn-2] 2025-11-05 • JPY 12500.00 @ Tokyo Metro | location: Tokyo, Kanto, Japan | PASMO CHARGE
+      - [txn-3] 2025-10-28 • USD 45.00 @ Amazon | AMAZON.COM ORDER
+      - [txn-4] 2025-11-16 • EUR 85.50 @ Cafe de Flore | location: Paris, Ile-de-France, France | CAFE DE FLORE PARIS
+    expected: |
+      {
+        "results": [
+          {
+            "transactionId": "txn-1",
+            "decision": "link",
+            "tripId": "trip-1",
+            "confidence": 0.95,
+            "reasoning": "Currency (JPY), location (Tokyo), and date (2025-11-03) all strongly match Tokyo Adventure trip"
+          },
+          {
+            "transactionId": "txn-2",
+            "decision": "link",
+            "tripId": "trip-1",
+            "confidence": 0.92,
+            "reasoning": "Tokyo Metro transaction in JPY during trip dates matches Tokyo Adventure trip"
+          },
+          {
+            "transactionId": "txn-3",
+            "decision": "skip",
+            "tripId": null,
+            "confidence": 0.1,
+            "reasoning": "Amazon purchase before any trip dates, no location match"
+          },
+          {
+            "transactionId": "txn-4",
+            "decision": "link",
+            "tripId": "trip-2",
+            "confidence": 0.93,
+            "reasoning": "EUR currency, Paris location, and date during Paris Vacation trip period"
+          }
+        ]
+      }
+
+evaluators:
+  - name: Response is valid JSON
+    string:
+      matchesRegex: '^\{.*\}$'
+
+  - name: Contains results array
+    string:
+      contains: '"results":'
+
+  - name: Has transactionId field
+    string:
+      contains: '"transactionId":'
+
+  - name: Has decision field
+    string:
+      contains: '"decision":'
+
+  - name: Has confidence field
+    string:
+      contains: '"confidence":'
+
+  - name: Has reasoning field
+    string:
+      contains: '"reasoning":'
+
+  - name: Decision values are valid
+    string:
+      matchesRegex: '"decision":\s*"(link|suggest|skip)"'
+
+  - name: Confidence is numeric 0-1
+    string:
+      matchesRegex: '"confidence":\s*(0(\.\d+)?|1(\.0+)?)'
+
+  - name: tripId exists for all entries
+    string:
+      matchesRegex: '"tripId":\s*("[\w-]+"|\s*null)'


### PR DESCRIPTION
Extract 4 embedded prompts from source code to centralized YAML files
in functions/prompts/ directory following existing template pattern.

New prompt files:
- trip-linking.prompt.yml: Matches transactions to trips with AI
- generate-spending-insights.prompt.yml: Analyzes monthly spending patterns
- enhance-visa-requirements.prompt.yml: Generates visa requirement data
- categorize-transaction.prompt.yml: Categorizes individual transactions

Updated source files to load prompts from YAML:
- tripLinking.ts: Uses Anthropic Claude for trip-transaction matching
- llmInsightsService.ts: Uses Claude for financial insights generation
- visaDataUpdater.ts: Uses OpenAI for visa requirement enrichment
- categorizationService.ts: Uses Claude Haiku for fallback categorization

Benefits:
- Centralized prompt management and version control
- Easier testing and validation with evaluators
- Consistent format across all AI prompts
- Dynamic variable templating ({{variable}}) support
- Model parameters externalized to YAML config