### PR TITLE
Show both photos side by side on mobile

### DIFF
--- a/src/app/tools/photo-feedback/session/[id]/page.tsx
+++ b/src/app/tools/photo-feedback/session/[id]/page.tsx
@@ -185,7 +185,7 @@ export default function PhotoBattleVotingPage() {
           Click a photo or press ← / → to choose which shot looks better.
         </p>
 
-        <div className="grid gap-3 md:grid-cols-2">
+        <div className="grid grid-cols-2 gap-3">
           {[{ side: "left" as const, card: pair.left }, { side: "right" as const, card: pair.right }].map(({ side, card }) => {
             const isSelected = selectedPhotoId === card.id;
             const previewUrl = card.thumbnailUrl ?? card.url;


### PR DESCRIPTION
## Summary
- ensure photo feedback session shows both competing images side by side on mobile screens

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e686176dc8327bae81ed7ba2b972d)