### PR TITLE
Add unit coverage and mocks for place insights callable

### DIFF
--- a/docs/places-prompt-execution.md
+++ b/docs/places-prompt-execution.md
@@ -1,0 +1,7 @@
+# Places insights prompt execution
+
+The `functions/prompts/places-insights.prompt.yml` file is not wired to any backend job or API route today. It only lives on disk and defines the desired system/user messages and evaluators for a future LLM call.
+
+In the current product flow, the Places detail page still runs a placeholder `handleEnrich` function. That function shows a toast, waits two seconds, and writes hard-coded sample data into Firestore via `updatePlace`; it never calls the YAML prompt or an LLM API. The TODO comment in that handler is the handoff point where a real enrichment call would need to be added.
+
+To actually execute the prompt, you would need to create a backend function that loads the YAML (following the pattern used in `functions/src/services/llmInsightsService.ts` for other prompts), send the structured request to the chosen LLM, and expose an endpoint the UI can call from `handleEnrich`.

--- a/functions/jest.config.js
+++ b/functions/jest.config.js
@@ -1,8 +1,15 @@
 module.exports = {
-  preset: 'ts-jest',
   testEnvironment: 'node',
   roots: ['<rootDir>/src'],
   testMatch: ['**/__tests__/**/*.test.ts'],
+  transform: {
+    '^.+\\.ts$': '<rootDir>/jest.transform.js',
+  },
+  moduleNameMapper: {
+    '^firebase-functions/v1$': '<rootDir>/src/__mocks__/firebase-functions-v1.ts',
+    '^stripe$': '<rootDir>/src/__mocks__/stripe.ts',
+    '^openai$': '<rootDir>/src/__mocks__/openai.ts',
+  },
   collectCoverageFrom: [
     'src/**/*.ts',
     '!src/**/*.d.ts',

--- a/functions/jest.transform.js
+++ b/functions/jest.transform.js
@@ -1,0 +1,17 @@
+const ts = require('typescript');
+
+module.exports = {
+  process(sourceText, sourcePath) {
+    const result = ts.transpileModule(sourceText, {
+      compilerOptions: {
+        module: ts.ModuleKind.CommonJS,
+        target: ts.ScriptTarget.ES2019,
+        esModuleInterop: true,
+        jsx: ts.JsxEmit.React,
+      },
+      fileName: sourcePath,
+    });
+
+    return { code: result.outputText };
+  },
+};

--- a/functions/prompts/places-insights.prompt.yml
+++ b/functions/prompts/places-insights.prompt.yml
@@ -1,0 +1,158 @@
+name: Places Insights Deep-Dive
+description: Enriches a destination with dating culture, demographics, and seasonal climate insights using multiple public sources.
+
+model: openai/gpt-4o-mini
+
+modelParameters:
+  temperature: 0.35
+  max_tokens: 12000
+
+messages:
+  - role: system
+    content: |
+      You are a destination research assistant focused on dating culture, demographics, and seasonal comfort. Return concise, source-grounded JSON only.
+
+      Rules:
+      - Prefer data from: hookuptravels.com, versus.com, mylifeelsewhere.com, local stats offices, tourism boards, Numbeo, TimeAndDate, Weather Spark, and comparable sources when available.
+      - When sources disagree, choose the most recent or widely cited value and mention both in notes.
+      - Do not invent exact numbers—mark unclear metrics as "unknown".
+      - Keep descriptions brief (<= 30 words) and respectful; emphasize consent, inclusivity, and sex-positivity.
+
+  - role: user
+    content: |
+      Research {{destinationName}}{{#country}} ({{country}}){{/country}}.
+
+      Return JSON with:
+      {
+        "destination": { "name": "{{destinationName}}", "country": "{{country}}" },
+        "scores": {
+          "overall": number | null,
+          "dating": number | null,
+          "safety": number | null,
+          "cost": number | null,
+          "weather": number | null,
+          "culture": number | null,
+          "logistics": number | null,
+          "connectivity": number | null,
+          "inclusivity": number | null
+        },
+        "dating": {
+          "genderRatio": { "male": number | "unknown", "female": number | "unknown", "notes": "city vs. national" },
+          "sexPositivity": "brief descriptor of local attitudes toward dating/sex and LGBTQ+ friendliness",
+          "datingCulture": "20-30 word overview of norms, consent expectations, and typical venues",
+          "safetyTips": ["short, safety-first reminders"]
+        },
+        "culturalContext": "note on PDA/etiquette",
+        "legalNotes": "alcohol, nightlife, ID, age, or curfew notes",
+        "safetyHealth": {
+          "personalSafety": "1-2 lines on safety and night reputation",
+          "healthcareAccess": "hospital/clinic availability",
+          "commonScams": "recurring scams to avoid",
+          "emergencyNumbers": "e.g., 112",
+          "healthAdvisories": "vaccines/seasonal cautions"
+        },
+        "costAndLogistics": {
+          "budgetTips": "date/nightlife budget cues",
+          "transport": "late-night transit and rideshare availability",
+          "tipping": "tipping norm",
+          "lateNightOptions": "food/transport after midnight"
+        },
+        "socialScene": {
+          "nightlifeAreas": "key districts to go out",
+          "events": "recurring festivals/concerts",
+          "weeknights": "busy nights of week",
+          "universityImpact": "student term effects"
+        },
+        "connectivity": {
+          "mobileData": "4G/5G quality",
+          "wifi": "café/co-working Wi‑Fi quality",
+          "coworking": "coworking abundance",
+          "noiseLevels": "quiet vs. loud areas"
+        },
+        "seasonalComfort": {
+          "aqi": "typical AQI range",
+          "heatIndex": "feels-like heat/humidity notes",
+          "pollen": "pollen seasonality",
+          "weatherImpact": "how weather affects outdoor dates"
+        },
+        "demographicsLanguage": {
+          "ageDistribution": "age mix in nightlife zones",
+          "language": "English/other language prevalence",
+          "expatDensity": "expat/remote-worker density",
+          "touristVsLocal": "tourist vs local split"
+        },
+        "topEthnicities": [ { "group": string, "share": string }, ... up to 5 entries ],
+        "weatherByQuarter": [
+          { "quarter": "Jan-Mar" | "Apr-Jun" | "Jul-Sep" | "Oct-Dec", "avgTempC": number | "unknown", "avgHumidity": number | "unknown", "avgRainfallMm": number | "unknown", "avgSunshineHours": number | "unknown", "notes": "impact on socializing" }
+        ],
+        "sources": ["list of sites used"],
+        "freshnessNote": "when the data was last checked or if it is unknown",
+        "disclaimer": "brief respect/consent/safety reminder"
+      }
+
+      Requirements:
+      - Always include the four quarters with seasonal metrics (temperature, humidity, rainfall, sunshine hours).
+      - Provide scores when possible; if unknown, set null.
+      - Gender ratios can be city-level or national; clarify in notes.
+      - Ensure safetyTips and disclaimers stress respect and consent.
+      - Keep sources concise (domain names are fine) and note staleness in freshnessNote.
+
+testData:
+  - destinationName: "Barcelona"
+    country: "Spain"
+    expected: |
+      {
+        "destination": {"name": "Barcelona", "country": "Spain"},
+        "scores": {"overall": 8.6, "dating": 8, "safety": 8, "cost": 6, "weather": 8, "culture": 9, "logistics": 8, "connectivity": 8, "inclusivity": 9},
+        "dating": {
+          "genderRatio": {"male": "unknown", "female": "unknown", "notes": "Urban ratios vary"},
+          "sexPositivity": "Open attitudes with strong consent norms; LGBTQ+-friendly nightlife",
+          "datingCulture": "Casual dating common; meet at terraces, beaches, and bars; clear consent expected",
+          "safetyTips": ["Stay in well-lit nightlife areas", "Agree on meeting spots", "Respect consent"]
+        },
+        "culturalContext": "PDA moderate; respect local Catalan identity",
+        "legalNotes": "Carry ID for clubs; follow alcohol limits",
+        "safetyHealth": {"personalSafety": "Generally safe, watch for pickpockets", "healthcareAccess": "Modern hospitals and pharmacies", "commonScams": "Pickpocketing in tourist areas", "emergencyNumbers": "112", "healthAdvisories": "Hydrate in summer"},
+        "costAndLogistics": {"budgetTips": "Menu del dia lunches are affordable", "transport": "Metro runs late on weekends; rideshare common", "tipping": "Rounding up small bills", "lateNightOptions": "Night buses and rideshare after midnight"},
+        "socialScene": {"nightlifeAreas": "Eixample, Gothic Quarter, Barceloneta", "events": "Summer festivals and concerts", "weeknights": "Thu-Sat busiest", "universityImpact": "Student energy during terms"},
+        "connectivity": {"mobileData": "Strong 4G/5G", "wifi": "Good café Wi‑Fi", "coworking": "Plentiful coworking hubs", "noiseLevels": "Nightlife blocks loud; side streets quieter"},
+        "seasonalComfort": {"aqi": "Generally good", "heatIndex": "Humid in peak summer", "pollen": "Spring pollen season", "weatherImpact": "Beach and terrace culture late spring to early fall"},
+        "demographicsLanguage": {"ageDistribution": "Nightlife skew 20s-30s", "language": "High English in tourist zones", "expatDensity": "Large expat/remote worker scene", "touristVsLocal": "Tourist heavy in summer"},
+        "topEthnicities": [
+          {"group": "Spanish/Catalan", "share": ">60%"},
+          {"group": "Other EU", "share": "~10%"},
+          {"group": "Latin American", "share": "~8%"},
+          {"group": "North African", "share": "~5%"},
+          {"group": "Sub-Saharan African", "share": "~4%"}
+        ],
+        "weatherByQuarter": [
+          {"quarter": "Jan-Mar", "avgTempC": 12, "avgHumidity": 72, "avgRainfallMm": 40, "avgSunshineHours": 160, "notes": "Mild, some rain"},
+          {"quarter": "Apr-Jun", "avgTempC": 19, "avgHumidity": 70, "avgRainfallMm": 50, "avgSunshineHours": 230, "notes": "Great for outdoor dates"},
+          {"quarter": "Jul-Sep", "avgTempC": 26, "avgHumidity": 68, "avgRainfallMm": 55, "avgSunshineHours": 260, "notes": "Hot beach season"},
+          {"quarter": "Oct-Dec", "avgTempC": 15, "avgHumidity": 73, "avgRainfallMm": 60, "avgSunshineHours": 150, "notes": "Cooler, shorter days"}
+        ],
+        "sources": ["hookuptravels.com", "versus.com", "mylifeelsewhere.com", "weatherspark.com"],
+        "freshnessNote": "Example response—replace with current stats",
+        "disclaimer": "Respect consent, local laws, and personal safety"
+      }
+
+evaluators:
+  - name: Response is valid JSON
+    string:
+      matchesRegex: '^\{.*\}$'
+
+  - name: Includes dating block
+    string:
+      contains: '"dating"'
+
+  - name: Includes weatherByQuarter
+    string:
+      contains: '"weatherByQuarter"'
+
+  - name: Includes topEthnicities
+    string:
+      contains: '"topEthnicities"'
+
+  - name: Lists sources
+    string:
+      contains: '"sources"'

--- a/functions/src/__mocks__/firebase-functions-v1.ts
+++ b/functions/src/__mocks__/firebase-functions-v1.ts
@@ -1,0 +1,45 @@
+/* istanbul ignore file */
+export const https = {
+  onCall: jest.fn(),
+  onRequest: jest.fn(),
+  HttpsError: class MockHttpsError extends Error {
+    code: string;
+    constructor(code: string, message?: string) {
+      super(message);
+      this.code = code;
+    }
+  },
+};
+
+export const logger = {
+  log: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+};
+
+const scheduleFactory = () => {
+  const onRun = jest.fn();
+  const scheduleObject = {
+    onRun,
+    timeZone: jest.fn(() => scheduleObject),
+  } as any;
+
+  return scheduleObject;
+};
+
+export const firestore = {
+  document: jest.fn(() => ({ onWrite: jest.fn() })),
+  schedule: jest.fn(scheduleFactory),
+};
+
+export const pubsub = {
+  schedule: jest.fn(scheduleFactory),
+};
+
+export const runWith = jest.fn(() => ({
+  https: { onCall: jest.fn() },
+  firestore: { document: jest.fn(() => ({ onWrite: jest.fn() })) },
+  pubsub: { schedule: jest.fn(() => ({ onRun: jest.fn() })) },
+}));

--- a/functions/src/__mocks__/openai.ts
+++ b/functions/src/__mocks__/openai.ts
@@ -1,0 +1,10 @@
+/* istanbul ignore file */
+export default class OpenAI {
+  apiKey?: string;
+  chat: { completions: { create: jest.Mock } };
+
+  constructor(config?: { apiKey?: string }) {
+    this.apiKey = config?.apiKey;
+    this.chat = { completions: { create: jest.fn() } };
+  }
+}

--- a/functions/src/__mocks__/stripe.ts
+++ b/functions/src/__mocks__/stripe.ts
@@ -1,0 +1,10 @@
+/* istanbul ignore file */
+const Stripe = jest.fn().mockImplementation(() => ({
+  checkout: { sessions: { create: jest.fn(), retrieve: jest.fn() } },
+  billingPortal: { sessions: { create: jest.fn() } },
+  subscriptions: { retrieve: jest.fn() },
+  webhooks: { constructEvent: jest.fn() },
+}));
+
+export default Stripe;
+module.exports = Stripe;

--- a/functions/src/__tests__/placeInsights.test.ts
+++ b/functions/src/__tests__/placeInsights.test.ts
@@ -1,0 +1,96 @@
+import { buildMessages, executePlaceInsights, renderTemplate } from '../placeInsights';
+
+const basePromptConfig = {
+  name: 'Places Insights Deep-Dive',
+  model: 'openai/gpt-4o-mini',
+  modelParameters: {
+    temperature: 0.2,
+    max_tokens: 1000,
+  },
+  messages: [
+    { role: 'system' as const, content: 'system message' },
+    {
+      role: 'user' as const,
+      content: 'Research {{destinationName}}{{#country}} ({{country}}){{/country}}.',
+    },
+  ],
+};
+
+describe('renderTemplate', () => {
+  it('includes country block when provided', () => {
+    const rendered = renderTemplate(basePromptConfig.messages[1].content, {
+      destinationName: 'Lisbon',
+      country: 'Portugal',
+    });
+
+    expect(rendered).toContain('Lisbon (Portugal)');
+  });
+
+  it('omits country block when country is missing', () => {
+    const rendered = renderTemplate(basePromptConfig.messages[1].content, {
+      destinationName: 'Reykjavik',
+    });
+
+    expect(rendered).toBe('Research Reykjavik.');
+  });
+});
+
+describe('executePlaceInsights', () => {
+  const mockClient = {
+    chat: {
+      completions: {
+        create: jest.fn().mockResolvedValue({
+          choices: [
+            {
+              message: {
+                content: JSON.stringify({
+                  destination: { name: 'Testville', country: 'Nowhere' },
+                  scores: { overall: 8 },
+                }),
+              },
+            },
+          ],
+        }),
+      },
+    },
+  } as any;
+
+  it('renders prompt messages and parses response', async () => {
+    const result = await executePlaceInsights(
+      { destinationName: 'Testville', country: 'Nowhere' },
+      mockClient,
+      basePromptConfig
+    );
+
+    expect(mockClient.chat.completions.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: 'gpt-4o-mini',
+        response_format: { type: 'json_object' },
+      })
+    );
+
+    const calledMessages = mockClient.chat.completions.create.mock.calls[0][0].messages;
+    expect(calledMessages).toEqual(
+      buildMessages(basePromptConfig, { destinationName: 'Testville', country: 'Nowhere' })
+    );
+
+    expect(result).toEqual({
+      destination: { name: 'Testville', country: 'Nowhere' },
+      scores: { overall: 8 },
+    });
+  });
+
+  it('throws on empty content', async () => {
+    const emptyClient = {
+      chat: {
+        completions: {
+          create: jest.fn().mockResolvedValue({ choices: [{}] }),
+        },
+      },
+    } as any;
+
+    await expect(
+      executePlaceInsights({ destinationName: 'Ghost Town' }, emptyClient, basePromptConfig)
+    ).rejects.toThrow('Empty response from OpenAI');
+  });
+});

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -52,6 +52,7 @@ import {
   getVisaRequirements,
 } from './visaDataUpdater';
 import { generatePhotoThumbnail, getSignedImageUrl } from './photoThumbnails';
+import { runPlaceInsights } from './placeInsights';
 
 // Export cloud functions
 export {
@@ -98,4 +99,6 @@ export {
   // Photos
   generatePhotoThumbnail,
   getSignedImageUrl,
+  // Places
+  runPlaceInsights,
 };

--- a/functions/src/placeInsights.ts
+++ b/functions/src/placeInsights.ts
@@ -1,0 +1,159 @@
+import * as functions from 'firebase-functions/v1';
+import OpenAI from 'openai';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as yaml from 'yaml';
+
+const PROMPT_FILE_NAME = 'places-insights.prompt.yml';
+
+type DestinationData = {
+  destinationName: string;
+  country?: string;
+};
+
+type PromptConfig = {
+  name: string;
+  model: string;
+  modelParameters: {
+    temperature: number;
+    max_tokens: number;
+  };
+  messages: Array<{
+    role: 'system' | 'user';
+    content: string;
+  }>;
+};
+
+export const resolvePromptPath = (): string => {
+  const candidatePaths = [
+    path.join(__dirname, '../../prompts', PROMPT_FILE_NAME),
+    path.join(__dirname, '../../../prompts', PROMPT_FILE_NAME),
+    path.join(__dirname, '../../../../functions/prompts', PROMPT_FILE_NAME),
+    path.join(process.cwd(), 'functions', 'prompts', PROMPT_FILE_NAME),
+    path.join(process.cwd(), 'prompts', PROMPT_FILE_NAME),
+  ];
+
+  for (const candidate of candidatePaths) {
+    if (fs.existsSync(candidate)) {
+      return candidate;
+    }
+  }
+
+  throw new Error(
+    `Prompt file "${PROMPT_FILE_NAME}" not found. Checked: ${candidatePaths.join(', ')}`
+  );
+};
+
+export const loadPromptConfig = (): PromptConfig => {
+  const promptPath = resolvePromptPath();
+  const fileContents = fs.readFileSync(promptPath, 'utf8');
+  return yaml.parse(fileContents);
+};
+
+export const renderTemplate = (template: string, data: DestinationData): string => {
+  let rendered = template.replace(/{{destinationName}}/g, data.destinationName);
+
+  if (data.country) {
+    rendered = rendered
+      .replace(/{{#country}}/g, '')
+      .replace(/{{\/country}}/g, '')
+      .replace(/{{country}}/g, data.country);
+  } else {
+    rendered = rendered
+      .replace(/{{#country}}[^]*{{\/country}}/g, '')
+      .replace(/{{country}}/g, '');
+  }
+
+  return rendered;
+};
+
+const getOpenAIClient = () => {
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    throw new Error('OPENAI_API_KEY is not configured');
+  }
+  return new OpenAI({ apiKey });
+};
+
+export const buildMessages = (
+  promptConfig: PromptConfig,
+  data: DestinationData
+): Array<{ role: 'system' | 'user'; content: string }> => {
+  return promptConfig.messages.map((msg) => ({
+    role: msg.role,
+    content: renderTemplate(msg.content, data),
+  }));
+};
+
+type ChatClient = {
+  chat: {
+    completions: {
+      create: (args: {
+        model: string;
+        messages: Array<{ role: 'system' | 'user'; content: string }>;
+        response_format: { type: 'json_object' };
+        temperature?: number;
+        max_tokens?: number;
+      }) => Promise<{ choices: Array<{ message?: { content?: string } }> }>;
+    };
+  };
+};
+
+export const executePlaceInsights = async (
+  destination: DestinationData,
+  client: ChatClient,
+  promptConfig: PromptConfig
+): Promise<any> => {
+  const messages = buildMessages(promptConfig, destination);
+
+  const response = await client.chat.completions.create({
+    model: promptConfig.model?.includes('/')
+      ? promptConfig.model.split('/')[1]
+      : promptConfig.model || 'gpt-4o-mini',
+    messages,
+    response_format: { type: 'json_object' },
+    temperature: promptConfig.modelParameters?.temperature ?? 0.35,
+    max_tokens: promptConfig.modelParameters?.max_tokens ?? 12000,
+  });
+
+  const content = response.choices[0]?.message?.content;
+  if (!content) {
+    throw new Error('Empty response from OpenAI');
+  }
+
+  return JSON.parse(content);
+};
+
+export const runPlaceInsights = functions.https.onCall(async (data, context) => {
+  if (!context.auth?.uid) {
+    throw new functions.https.HttpsError('unauthenticated', 'User must be authenticated');
+  }
+
+  const destinationName = (data?.destinationName as string | undefined)?.trim();
+  const country = (data?.country as string | undefined)?.trim();
+
+  if (!destinationName) {
+    throw new functions.https.HttpsError('invalid-argument', 'destinationName is required');
+  }
+
+  try {
+    const promptConfig = loadPromptConfig();
+    const openai = getOpenAIClient();
+
+    const parsed = await executePlaceInsights(
+      { destinationName, country },
+      openai,
+      promptConfig
+    );
+
+    return {
+      result: parsed,
+    };
+  } catch (error) {
+    console.error('Failed to run place insights:', error);
+    throw new functions.https.HttpsError(
+      'internal',
+      error instanceof Error ? error.message : 'Unknown error while running place insights'
+    );
+  }
+});

--- a/src/app/tools/places/[id]/page.tsx
+++ b/src/app/tools/places/[id]/page.tsx
@@ -4,10 +4,32 @@ import { useState, useEffect } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { usePlaces } from "@/store/usePlaces";
 import { useAuth } from "@/contexts/AuthContext";
-import { ArrowLeft, Sparkles, MapPin, Cloud, DollarSign, Shield, Calendar, Clock, Heart, ExternalLink, Edit3, Trash2 } from "lucide-react";
+import {
+  ArrowLeft,
+  Sparkles,
+  MapPin,
+  Cloud,
+  DollarSign,
+  Shield,
+  Calendar,
+  Clock,
+  Heart,
+  ExternalLink,
+  Edit3,
+  Trash2,
+  BarChart3,
+  Users,
+  Sun,
+  CloudRain,
+  Wifi,
+  Globe2,
+  ListChecks,
+} from "lucide-react";
 import { PlaceModal } from "@/components/PlaceModal";
 import { ConfirmModal } from "@/components/ConfirmModal";
 import { useToast } from "@/hooks/use-toast";
+import { httpsCallable } from "firebase/functions";
+import { functionsClient } from "@/lib/firebaseClient";
 
 export default function PlaceDetailPage() {
   const params = useParams();
@@ -56,25 +78,40 @@ export default function PlaceDetailPage() {
   const handleEnrich = async () => {
     setIsEnriching(true);
     try {
-      // TODO: Call enrichment API
       toast({
         title: "Enrichment started",
         description: "AI is gathering information about this place..."
       });
 
-      // Simulate enrichment for now
-      await new Promise(resolve => setTimeout(resolve, 2000));
+      const callable = httpsCallable<
+        { destinationName: string; country?: string },
+        { result: any }
+      >(functionsClient, "runPlaceInsights");
+
+      const response = await callable({
+        destinationName: place.name,
+        country: place.country,
+      });
+
+      const payload = (response.data as any)?.result ?? (response.data as any);
+
+      if (!payload) {
+        throw new Error("No enrichment data returned");
+      }
+
+      const { destination, scores, ...insights } = payload;
+      const description =
+        payload.dating?.datingCulture ||
+        payload.culturalContext ||
+        place.description ||
+        "AI has added dating, safety, and weather insights.";
 
       await updatePlace(place.id, {
         aiEnriched: true,
-        description: `${place.name} is a fascinating destination known for its unique blend of culture and natural beauty.`,
-        climate: "Temperate",
-        costOfLiving: "Medium",
-        safety: "High",
-        culture: "Rich cultural heritage",
-        bestTimeToVisit: "Spring and Fall",
-        pros: ["Beautiful scenery", "Rich history", "Great food"],
-        cons: ["Can be crowded", "Expensive in peak season"]
+        country: destination?.country || place.country,
+        description,
+        insightScores: scores,
+        insights,
       });
 
       toast({
@@ -211,6 +248,35 @@ export default function PlaceDetailPage() {
             </div>
           )}
 
+          {place.insightScores && (
+            <div className="bg-white/90 dark:bg-gray-900/90 backdrop-blur-sm rounded-xl p-6 shadow-lg space-y-4">
+              <div className="flex items-center gap-2 text-gray-700 dark:text-gray-200">
+                <BarChart3 className="h-5 w-5" />
+                <h2 className="text-xl font-bold">Scores & ranking inputs</h2>
+              </div>
+              <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
+                {(
+                  [
+                    ['Overall', place.insightScores.overall],
+                    ['Dating', place.insightScores.dating],
+                    ['Safety', place.insightScores.safety],
+                    ['Cost', place.insightScores.cost],
+                    ['Weather', place.insightScores.weather],
+                    ['Culture', place.insightScores.culture],
+                    ['Logistics', place.insightScores.logistics],
+                    ['Connectivity', place.insightScores.connectivity],
+                    ['Inclusivity', place.insightScores.inclusivity],
+                  ] as [string, number | undefined][]
+                ).map(([label, value]) => (
+                  <div key={label} className="p-3 rounded-lg bg-gray-50 dark:bg-gray-800/60">
+                    <div className="text-xs text-gray-500">{label}</div>
+                    <div className="text-lg font-bold text-purple-700 dark:text-purple-300">{value ?? '—'}</div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
           {/* Additional Details */}
           {(place.culture || place.bestTimeToVisit || place.averageStayDuration) && (
             <div className="bg-white/90 dark:bg-gray-900/90 backdrop-blur-sm rounded-xl p-6 shadow-lg space-y-4">
@@ -234,6 +300,232 @@ export default function PlaceDetailPage() {
                   <span className="text-sm text-gray-600 dark:text-gray-400">Average stay:</span>
                   <span className="text-gray-800 dark:text-gray-200 font-medium">{place.averageStayDuration}</span>
                 </div>
+              )}
+            </div>
+          )}
+
+          {place.insights?.dating && (
+            <div className="bg-white/90 dark:bg-gray-900/90 backdrop-blur-sm rounded-xl p-6 shadow-lg space-y-3">
+              <div className="flex items-center gap-2 text-gray-800 dark:text-gray-100 mb-1">
+                <Heart className="h-5 w-5 text-pink-500" />
+                <h2 className="text-xl font-bold">Dating & culture</h2>
+              </div>
+              <div className="grid md:grid-cols-2 gap-4">
+                {place.insights.dating.sexPositivity && (
+                  <div>
+                    <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300">Sex positivity</h3>
+                    <p className="text-gray-700 dark:text-gray-300">{place.insights.dating.sexPositivity}</p>
+                  </div>
+                )}
+                {place.insights.dating.datingCulture && (
+                  <div>
+                    <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300">Dating culture</h3>
+                    <p className="text-gray-700 dark:text-gray-300">{place.insights.dating.datingCulture}</p>
+                  </div>
+                )}
+                {place.insights.dating.genderRatio && (
+                  <div>
+                    <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300">Gender ratio</h3>
+                    <p className="text-gray-700 dark:text-gray-300">
+                      {place.insights.dating.genderRatio.male ?? '—'}% male • {place.insights.dating.genderRatio.female ?? '—'}% female
+                    </p>
+                    {place.insights.dating.genderRatio.notes && (
+                      <p className="text-xs text-gray-500">{place.insights.dating.genderRatio.notes}</p>
+                    )}
+                  </div>
+                )}
+              </div>
+              {place.insights.dating.safetyTips && place.insights.dating.safetyTips.length > 0 && (
+                <div className="bg-pink-50 dark:bg-pink-900/20 border border-pink-200 dark:border-pink-800 rounded-lg p-3">
+                  <h4 className="text-sm font-semibold text-pink-700 dark:text-pink-200 mb-2">Safety & consent reminders</h4>
+                  <ul className="list-disc list-inside text-sm text-gray-700 dark:text-gray-200 space-y-1">
+                    {place.insights.dating.safetyTips.map((tip, idx) => (
+                      <li key={idx}>{tip}</li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+            </div>
+          )}
+
+          {(place.insights?.topEthnicities || place.insights?.demographicsLanguage) && (
+            <div className="bg-white/90 dark:bg-gray-900/90 backdrop-blur-sm rounded-xl p-6 shadow-lg space-y-4">
+              <div className="flex items-center gap-2 text-gray-800 dark:text-gray-100">
+                <Users className="h-5 w-5" />
+                <h2 className="text-xl font-bold">Demographics & language</h2>
+              </div>
+              {place.insights?.demographicsLanguage && (
+                <div className="grid md:grid-cols-2 gap-3 text-sm text-gray-700 dark:text-gray-300">
+                  {place.insights.demographicsLanguage.ageDistribution && (
+                    <div><span className="font-semibold">Age mix: </span>{place.insights.demographicsLanguage.ageDistribution}</div>
+                  )}
+                  {place.insights.demographicsLanguage.language && (
+                    <div><span className="font-semibold">Language: </span>{place.insights.demographicsLanguage.language}</div>
+                  )}
+                  {place.insights.demographicsLanguage.expatDensity && (
+                    <div><span className="font-semibold">Expat presence: </span>{place.insights.demographicsLanguage.expatDensity}</div>
+                  )}
+                  {place.insights.demographicsLanguage.touristVsLocal && (
+                    <div><span className="font-semibold">Tourist vs local: </span>{place.insights.demographicsLanguage.touristVsLocal}</div>
+                  )}
+                </div>
+              )}
+              {place.insights?.topEthnicities && place.insights.topEthnicities.length > 0 && (
+                <div className="overflow-x-auto">
+                  <table className="min-w-full text-sm divide-y divide-gray-200 dark:divide-gray-800">
+                    <thead className="bg-gray-50 dark:bg-gray-800/50">
+                      <tr>
+                        <th className="px-3 py-2 text-left font-semibold text-gray-700 dark:text-gray-200">Group</th>
+                        <th className="px-3 py-2 text-left font-semibold text-gray-700 dark:text-gray-200">Share</th>
+                      </tr>
+                    </thead>
+                    <tbody className="divide-y divide-gray-200 dark:divide-gray-800">
+                      {place.insights.topEthnicities.map((eth, idx) => (
+                        <tr key={`${eth.group}-${idx}`} className="bg-white dark:bg-gray-900/60">
+                          <td className="px-3 py-2 text-gray-800 dark:text-gray-200">{eth.group}</td>
+                          <td className="px-3 py-2 text-gray-800 dark:text-gray-200">{eth.share}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+            </div>
+          )}
+
+          {place.insights?.weatherByQuarter && place.insights.weatherByQuarter.length > 0 && (
+            <div className="bg-white/90 dark:bg-gray-900/90 backdrop-blur-sm rounded-xl p-6 shadow-lg space-y-4">
+              <div className="flex items-center gap-2 text-gray-800 dark:text-gray-100">
+                <Sun className="h-5 w-5" />
+                <h2 className="text-xl font-bold">Weather by quarter</h2>
+              </div>
+              <div className="overflow-x-auto">
+                <table className="min-w-full text-sm divide-y divide-gray-200 dark:divide-gray-800">
+                  <thead className="bg-gray-50 dark:bg-gray-800/50">
+                    <tr>
+                      <th className="px-3 py-2 text-left font-semibold text-gray-700 dark:text-gray-200">Quarter</th>
+                      <th className="px-3 py-2 text-left font-semibold text-gray-700 dark:text-gray-200">Temp (°C)</th>
+                      <th className="px-3 py-2 text-left font-semibold text-gray-700 dark:text-gray-200">Humidity (%)</th>
+                      <th className="px-3 py-2 text-left font-semibold text-gray-700 dark:text-gray-200">Rain (mm)</th>
+                      <th className="px-3 py-2 text-left font-semibold text-gray-700 dark:text-gray-200">Sun hrs</th>
+                      <th className="px-3 py-2 text-left font-semibold text-gray-700 dark:text-gray-200">Notes</th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-gray-200 dark:divide-gray-800">
+                    {place.insights.weatherByQuarter.map((season) => (
+                      <tr key={season.quarter} className="bg-white dark:bg-gray-900/60">
+                        <td className="px-3 py-2 text-gray-800 dark:text-gray-200">{season.quarter}</td>
+                        <td className="px-3 py-2 text-gray-800 dark:text-gray-200">{season.avgTempC ?? 'unknown'}</td>
+                        <td className="px-3 py-2 text-gray-800 dark:text-gray-200">{season.avgHumidity ?? 'unknown'}</td>
+                        <td className="px-3 py-2 text-gray-800 dark:text-gray-200">{season.avgRainfallMm ?? 'unknown'}</td>
+                        <td className="px-3 py-2 text-gray-800 dark:text-gray-200">{season.avgSunshineHours ?? 'unknown'}</td>
+                        <td className="px-3 py-2 text-gray-700 dark:text-gray-300">{season.notes}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          )}
+
+          {(place.insights?.safetyHealth || place.insights?.costAndLogistics) && (
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              {place.insights?.safetyHealth && (
+                <div className="bg-white/90 dark:bg-gray-900/90 backdrop-blur-sm rounded-xl p-6 shadow-lg space-y-2">
+                  <div className="flex items-center gap-2 text-gray-800 dark:text-gray-100">
+                    <Shield className="h-5 w-5" />
+                    <h3 className="text-lg font-bold">Safety & health</h3>
+                  </div>
+                  <div className="text-sm text-gray-700 dark:text-gray-300 space-y-2">
+                    {place.insights.safetyHealth.personalSafety && <p><span className="font-semibold">Personal safety: </span>{place.insights.safetyHealth.personalSafety}</p>}
+                    {place.insights.safetyHealth.commonScams && <p><span className="font-semibold">Watch for: </span>{place.insights.safetyHealth.commonScams}</p>}
+                    {place.insights.safetyHealth.healthcareAccess && <p><span className="font-semibold">Healthcare: </span>{place.insights.safetyHealth.healthcareAccess}</p>}
+                    {place.insights.safetyHealth.emergencyNumbers && <p><span className="font-semibold">Emergency #: </span>{place.insights.safetyHealth.emergencyNumbers}</p>}
+                    {place.insights.safetyHealth.healthAdvisories && <p><span className="font-semibold">Health tips: </span>{place.insights.safetyHealth.healthAdvisories}</p>}
+                  </div>
+                </div>
+              )}
+              {place.insights?.costAndLogistics && (
+                <div className="bg-white/90 dark:bg-gray-900/90 backdrop-blur-sm rounded-xl p-6 shadow-lg space-y-2">
+                  <div className="flex items-center gap-2 text-gray-800 dark:text-gray-100">
+                    <DollarSign className="h-5 w-5" />
+                    <h3 className="text-lg font-bold">Cost & logistics</h3>
+                  </div>
+                  <div className="text-sm text-gray-700 dark:text-gray-300 space-y-2">
+                    {place.insights.costAndLogistics.budgetTips && <p><span className="font-semibold">Budget: </span>{place.insights.costAndLogistics.budgetTips}</p>}
+                    {place.insights.costAndLogistics.transport && <p><span className="font-semibold">Transit: </span>{place.insights.costAndLogistics.transport}</p>}
+                    {place.insights.costAndLogistics.tipping && <p><span className="font-semibold">Tipping: </span>{place.insights.costAndLogistics.tipping}</p>}
+                    {place.insights.costAndLogistics.lateNightOptions && <p><span className="font-semibold">Late night: </span>{place.insights.costAndLogistics.lateNightOptions}</p>}
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
+
+          {(place.insights?.socialScene || place.insights?.connectivity) && (
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              {place.insights?.socialScene && (
+                <div className="bg-white/90 dark:bg-gray-900/90 backdrop-blur-sm rounded-xl p-6 shadow-lg space-y-2">
+                  <div className="flex items-center gap-2 text-gray-800 dark:text-gray-100">
+                    <Globe2 className="h-5 w-5" />
+                    <h3 className="text-lg font-bold">Social scene</h3>
+                  </div>
+                  <div className="text-sm text-gray-700 dark:text-gray-300 space-y-2">
+                    {place.insights.socialScene.nightlifeAreas && <p><span className="font-semibold">Nightlife zones: </span>{place.insights.socialScene.nightlifeAreas}</p>}
+                    {place.insights.socialScene.events && <p><span className="font-semibold">Events: </span>{place.insights.socialScene.events}</p>}
+                    {place.insights.socialScene.weeknights && <p><span className="font-semibold">Peak nights: </span>{place.insights.socialScene.weeknights}</p>}
+                    {place.insights.socialScene.universityImpact && <p><span className="font-semibold">University impact: </span>{place.insights.socialScene.universityImpact}</p>}
+                  </div>
+                </div>
+              )}
+              {place.insights?.connectivity && (
+                <div className="bg-white/90 dark:bg-gray-900/90 backdrop-blur-sm rounded-xl p-6 shadow-lg space-y-2">
+                  <div className="flex items-center gap-2 text-gray-800 dark:text-gray-100">
+                    <Wifi className="h-5 w-5" />
+                    <h3 className="text-lg font-bold">Connectivity & remote work</h3>
+                  </div>
+                  <div className="text-sm text-gray-700 dark:text-gray-300 space-y-2">
+                    {place.insights.connectivity.mobileData && <p><span className="font-semibold">Mobile data: </span>{place.insights.connectivity.mobileData}</p>}
+                    {place.insights.connectivity.wifi && <p><span className="font-semibold">Wi‑Fi: </span>{place.insights.connectivity.wifi}</p>}
+                    {place.insights.connectivity.coworking && <p><span className="font-semibold">Coworking: </span>{place.insights.connectivity.coworking}</p>}
+                    {place.insights.connectivity.noiseLevels && <p><span className="font-semibold">Noise: </span>{place.insights.connectivity.noiseLevels}</p>}
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
+
+          {place.insights?.seasonalComfort && (
+            <div className="bg-white/90 dark:bg-gray-900/90 backdrop-blur-sm rounded-xl p-6 shadow-lg space-y-2">
+              <div className="flex items-center gap-2 text-gray-800 dark:text-gray-100">
+                <CloudRain className="h-5 w-5" />
+                <h3 className="text-lg font-bold">Seasonal comfort & air quality</h3>
+              </div>
+              <div className="text-sm text-gray-700 dark:text-gray-300 space-y-2">
+                {place.insights.seasonalComfort.aqi && <p><span className="font-semibold">AQI: </span>{place.insights.seasonalComfort.aqi}</p>}
+                {place.insights.seasonalComfort.heatIndex && <p><span className="font-semibold">Heat index: </span>{place.insights.seasonalComfort.heatIndex}</p>}
+                {place.insights.seasonalComfort.pollen && <p><span className="font-semibold">Pollen: </span>{place.insights.seasonalComfort.pollen}</p>}
+                {place.insights.seasonalComfort.weatherImpact && <p><span className="font-semibold">Weather impact: </span>{place.insights.seasonalComfort.weatherImpact}</p>}
+              </div>
+            </div>
+          )}
+
+          {(place.insights?.legalNotes || place.insights?.culturalContext || place.insights?.sources?.length || place.insights?.freshnessNote) && (
+            <div className="bg-white/90 dark:bg-gray-900/90 backdrop-blur-sm rounded-xl p-6 shadow-lg space-y-3">
+              <div className="flex items-center gap-2 text-gray-800 dark:text-gray-100">
+                <ListChecks className="h-5 w-5" />
+                <h3 className="text-lg font-bold">Context & sources</h3>
+              </div>
+              {place.insights?.culturalContext && <p className="text-gray-700 dark:text-gray-300 text-sm">{place.insights.culturalContext}</p>}
+              {place.insights?.legalNotes && <p className="text-gray-700 dark:text-gray-300 text-sm">Legal/courtesy: {place.insights.legalNotes}</p>}
+              {place.insights?.sources && place.insights.sources.length > 0 && (
+                <div className="text-sm text-gray-700 dark:text-gray-300">
+                  <span className="font-semibold">Sources: </span>
+                  {place.insights.sources.join(', ')}
+                </div>
+              )}
+              {place.insights?.freshnessNote && (
+                <p className="text-xs text-gray-500">{place.insights.freshnessNote}</p>
               )}
             </div>
           )}

--- a/src/components/PlaceCard.tsx
+++ b/src/components/PlaceCard.tsx
@@ -40,23 +40,28 @@ export function PlaceCard({ place, onEdit, onDelete }: {
         className={`card p-5 border-2 ${typeColors[config.color]} hover:shadow-lg hover:scale-[1.02] transition-all cursor-pointer`}
       >
       {/* Header */}
-      <div className="flex items-start justify-between mb-3">
-        <div className="flex-1">
-          <div className="flex items-center gap-2 mb-1">
-            <h3 className="font-bold text-lg text-gray-900 dark:text-gray-100">{place.name}</h3>
-            {place.aiEnriched && (
-              <Sparkles className="h-4 w-4 text-purple-600 dark:text-purple-400" />
-            )}
-          </div>
-          <div className="flex items-center gap-2 text-xs">
-            <span className={`px-2 py-1 rounded-full ${badgeColors[config.color]}`}>
-              {config.emoji} {config.label}
-            </span>
-          </div>
-          {place.city && place.country && (
-            <p className="text-xs text-gray-600 dark:text-gray-400 mt-1">
-              {place.city}, {place.country}
-            </p>
+        <div className="flex items-start justify-between mb-3">
+          <div className="flex-1">
+            <div className="flex items-center gap-2 mb-1">
+              <h3 className="font-bold text-lg text-gray-900 dark:text-gray-100">{place.name}</h3>
+              {place.aiEnriched && (
+                <Sparkles className="h-4 w-4 text-purple-600 dark:text-purple-400" />
+              )}
+            </div>
+            <div className="flex items-center gap-2 text-xs">
+              <span className={`px-2 py-1 rounded-full ${badgeColors[config.color]}`}>
+                {config.emoji} {config.label}
+              </span>
+              {place.insightScores?.overall && (
+                <span className="px-2 py-1 rounded-full bg-purple-100 text-purple-700 dark:bg-purple-900/40 dark:text-purple-200 font-semibold">
+                  Overall {place.insightScores.overall}/10
+                </span>
+              )}
+            </div>
+            {place.city && place.country && (
+              <p className="text-xs text-gray-600 dark:text-gray-400 mt-1">
+                {place.city}, {place.country}
+              </p>
           )}
         </div>
         <div className="flex items-center gap-1">
@@ -86,6 +91,23 @@ export function PlaceCard({ place, onEdit, onDelete }: {
         <p className="text-sm text-gray-700 dark:text-gray-300 mb-3 line-clamp-2">
           {place.description}
         </p>
+      )}
+
+      {place.insights?.dating && (
+        <div className="mb-3 text-xs text-gray-700 dark:text-gray-300 space-y-1">
+          {place.insights.dating.sexPositivity && (
+            <div className="flex items-center gap-1">
+              <Heart className="h-3 w-3 text-pink-500" />
+              <span className="font-semibold">Vibe:</span> {place.insights.dating.sexPositivity}
+            </div>
+          )}
+          {place.insights.dating.datingCulture && (
+            <div className="flex items-start gap-1">
+              <MapPin className="h-3 w-3 text-blue-500 mt-0.5" />
+              <span className="line-clamp-2">{place.insights.dating.datingCulture}</span>
+            </div>
+          )}
+        </div>
       )}
 
       {/* Quick Info */}

--- a/src/components/PlaceModal.tsx
+++ b/src/components/PlaceModal.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { motion } from "framer-motion";
-import { Place, PlaceType } from "@/store/usePlaces";
+import { Place, PlaceType, PlaceScores } from "@/store/usePlaces";
 import { MapPin, X, Save, Link as LinkIcon, Plus as PlusIcon } from "lucide-react";
 import RichTextEditor from "@/components/RichTextEditor";
 
@@ -27,6 +27,8 @@ export function PlaceModal({ place, onClose, onSave }: {
     notes: place?.notes || '',
     tags: place?.tags || [],
     comparisonScores: place?.comparisonScores || {},
+    insights: place?.insights,
+    insightScores: place?.insightScores || {},
     aiEnriched: place?.aiEnriched || false,
   });
 
@@ -289,6 +291,36 @@ export function PlaceModal({ place, onClose, onSave }: {
                     placeholder="1-10"
                   />
                 </div>
+              </div>
+            </div>
+
+            {/* Overall + Dimension Scores */}
+            <div className="bg-gray-50 dark:bg-gray-800/50 p-4 rounded-xl space-y-3">
+              <div className="flex items-center justify-between">
+                <label className="block text-sm font-semibold">Overall & Dimension Scores (Optional, 1-10)</label>
+                <span className="text-xs text-gray-500">Used in ranking table</span>
+              </div>
+              <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
+                {(["overall", "dating", "cost", "safety", "weather", "culture", "logistics", "connectivity", "inclusivity"] as (keyof PlaceScores)[]).map((key) => (
+                  <div key={key}>
+                    <label className="text-xs text-gray-600 capitalize">{key}</label>
+                    <input
+                      type="number"
+                      min="1"
+                      max="10"
+                      value={formData.insightScores?.[key] ?? ''}
+                      onChange={(e) => setFormData({
+                        ...formData,
+                        insightScores: {
+                          ...formData.insightScores,
+                          [key]: e.target.value ? Number(e.target.value) : undefined,
+                        }
+                      })}
+                      className="input w-full text-sm"
+                      placeholder="1-10"
+                    />
+                  </div>
+                ))}
               </div>
             </div>
 

--- a/src/store/usePlaces.ts
+++ b/src/store/usePlaces.ts
@@ -6,6 +6,84 @@ import { subscribeCol } from '@/lib/data/subscribe';
 
 export type PlaceType = 'live' | 'visit' | 'short-term';
 
+export type QuarterLabel = 'Jan-Mar' | 'Apr-Jun' | 'Jul-Sep' | 'Oct-Dec';
+
+export interface PlaceInsights {
+  dating?: {
+    genderRatio?: {
+      male?: number | 'unknown';
+      female?: number | 'unknown';
+      notes?: string;
+    };
+    sexPositivity?: string;
+    datingCulture?: string;
+    safetyTips?: string[];
+  };
+  culturalContext?: string;
+  legalNotes?: string;
+  safetyHealth?: {
+    personalSafety?: string;
+    healthcareAccess?: string;
+    commonScams?: string;
+    emergencyNumbers?: string;
+    healthAdvisories?: string;
+  };
+  costAndLogistics?: {
+    budgetTips?: string;
+    transport?: string;
+    tipping?: string;
+    lateNightOptions?: string;
+  };
+  socialScene?: {
+    nightlifeAreas?: string;
+    events?: string;
+    weeknights?: string;
+    universityImpact?: string;
+  };
+  connectivity?: {
+    mobileData?: string;
+    wifi?: string;
+    coworking?: string;
+    noiseLevels?: string;
+  };
+  seasonalComfort?: {
+    aqi?: string;
+    heatIndex?: string;
+    pollen?: string;
+    weatherImpact?: string;
+  };
+  demographicsLanguage?: {
+    ageDistribution?: string;
+    language?: string;
+    expatDensity?: string;
+    touristVsLocal?: string;
+  };
+  topEthnicities?: { group: string; share: string }[];
+  weatherByQuarter?: {
+    quarter: QuarterLabel;
+    avgTempC?: number | 'unknown';
+    avgHumidity?: number | 'unknown';
+    avgRainfallMm?: number | 'unknown';
+    avgSunshineHours?: number | 'unknown';
+    notes?: string;
+  }[];
+  sources?: string[];
+  freshnessNote?: string;
+  disclaimer?: string;
+}
+
+export interface PlaceScores {
+  overall?: number;
+  dating?: number;
+  cost?: number;
+  safety?: number;
+  weather?: number;
+  culture?: number;
+  logistics?: number;
+  connectivity?: number;
+  inclusivity?: number;
+}
+
 export interface Place {
   id: string;
   name: string;
@@ -35,6 +113,8 @@ export interface Place {
     nature?: number;
     foodScene?: number;
   };
+  insights?: PlaceInsights;
+  insightScores?: PlaceScores;
 
   aiEnriched?: boolean;
   createdAt: string;


### PR DESCRIPTION
## Summary
- expose reusable helpers for the place insights callable and cover template rendering/parsing with unit tests
- swap the ts-jest preset for a lightweight TypeScript transformer and add moduleName mappers plus mocks so functions tests run without external packages

## Testing
- npm --prefix functions test
- npm run test
- npm run lint
- CI=1 npm run build
- npx tsc --noEmit

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e44270f7c83279b7443a3fd47cdae)