### PR TITLE
Fix photo feedback session image flickering

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -53,7 +53,7 @@ import {
 } from './visaDataUpdater';
 import { generatePhotoThumbnail, getSignedImageUrl } from './photoThumbnails';
 import { runPlaceInsights } from './placeInsights';
-import { submitPhotoVote, getNextPhotoPair, mergePhotos } from './photoVotes';
+import { submitPhotoVote, getNextPhotoPair, getNextPhotoPairs, mergePhotos } from './photoVotes';
 import {
   createPackingList,
   updatePackingList,
@@ -109,6 +109,7 @@ export {
   getSignedImageUrl,
   submitPhotoVote,
   getNextPhotoPair,
+  getNextPhotoPairs,
   mergePhotos,
   // Places
   runPlaceInsights,


### PR DESCRIPTION
Implemented efficient pagination for photo pair fetching to completely eliminate the glitchy flicker issue when selecting pairs.

**Root Cause:**
- After voting, reloadSession was called which created a new currentSession object
- This triggered a useEffect that completely reset the pair buffer
- Caused visible flicker: brief display of queued pair, then replaced with fresh pairs

**Solution:**
1. Backend: Added getNextPhotoPairs function that returns 10 pairs at once
2. Frontend: Replaced single-pair fetching with batch fetching
3. Buffer management: Only initialize buffer once per session, append new batches when low
4. Removed unnecessary reloadSession call after voting
5. Added session initialization tracking to prevent buffer resets

**Benefits:**
- 10x fewer cloud function calls (fetches 10 pairs at once)
- Smooth, flicker-free experience
- Once a pair is displayed, it stays visible
- Automatic refetch when buffer drops below 3 pairs
- Better performance and UX

**Changes:**
- functions/src/photoVotes.ts: Added getNextPhotoPairs function
- functions/src/index.ts: Exported new function
- src/store/usePhotoFeedback.ts: Added getNextPairs method
- src/app/tools/photo-feedback/session/[id]/page.tsx: Refactored to use pagination

Fixes photo-feedback flicker issue completely.