### PR TITLE
Reduce code coverage report

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -533,8 +533,8 @@ npx playwright test --headed
 
 ### Test Coverage Goals
 
-- **Unit Tests**: 70%+ coverage
-- **Critical Paths**: 90%+ coverage (auth, payments, data sync)
+- **Unit Tests**: 50%+ coverage
+- **Critical Paths**: 70%+ coverage (auth, payments, data sync)
 - **Edge Cases**: Test error conditions and boundaries
 
 ### When to Run Which Tests

--- a/functions/jest.config.js
+++ b/functions/jest.config.js
@@ -26,10 +26,10 @@ module.exports = {
   ],
   coverageThreshold: {
     global: {
-      branches: 70,
-      functions: 65,
-      lines: 70,
-      statements: 70,
+      branches: 50,
+      functions: 50,
+      lines: 50,
+      statements: 50,
     },
   },
 };


### PR DESCRIPTION
Reduce Jest coverage thresholds from 70% to 50% for better development velocity:
- functions/jest.config.js: branches, functions, lines, and statements now require 50% coverage (down from 65-70%)
- CLAUDE.md: Update documentation to reflect reduced requirements (50% for unit tests, 70% for critical paths)