### PR TITLE
feat: Enhance thought-to-calendar-event conversion with AI improvements

### DIFF
--- a/functions/prompts/process-thought.prompt.yml
+++ b/functions/prompts/process-thought.prompt.yml
@@ -64,7 +64,7 @@ messages:
          - Emotional states (mood)
          - Information to save (notes)
          - Errands or chores
-         - Calendar events (appointments, meetings, deadlines, scheduled activities)
+         - Calendar events (appointments, meetings, deadlines, scheduled activities with specific timing)
 
       2. **Match to Existing Data**: Review the user's current context:
          - Does this relate to an existing goal? → Use linkToGoal
@@ -80,7 +80,14 @@ messages:
 
       4. **Confidence Scoring**: For each action, provide a confidence score (0-100):
          - 99-100: Very high confidence, safe to auto-apply immediately
-         - 70-98: Medium confidence, show as suggestion for user approval
+           * ALWAYS use 99-100 when user explicitly says "create a calendar event" or similar directive
+           * Use for calendar events with explicit date/time like "tomorrow at 5pm"
+           * Use for appointments with clear scheduling details
+         - 90-98: High confidence, strongly recommended
+           * Calendar events with specific dates/times but without explicit "create event" directive
+           * Well-defined tasks and mood entries
+         - 70-89: Medium confidence, show as suggestion for user approval
+           * Actions that need interpretation or have some ambiguity
          - 0-69: Low confidence, do not suggest
 
       Respond ONLY with valid JSON (no markdown, no code blocks):
@@ -135,7 +142,17 @@ messages:
       - **Accurate Confidence**: High confidence (99-100) only when the relationship is obvious and unambiguous
       - **Include Context**: For link actions, always include "context" explaining what information this adds
       - **No Tag Actions**: Never use "addTag" - use specific entity creation or linking actions instead
-      - **Calendar Event Creation**: Use createCalendarEvent for thoughts with specific time references, appointments, meetings, deadlines, or scheduled activities. Include date (YYYY-MM-DD), time (HH:MM), location, description, and category (Work, Personal, Health, Social, Learning).
+      - **Calendar Event Creation - IMPORTANT RULES**:
+        * Use createCalendarEvent for thoughts with specific time references, appointments, meetings, deadlines, or scheduled activities
+        * Parse natural language dates: "tomorrow" = add 1 day, "next Monday" = find next occurrence of Monday, "in 2 weeks" = add 14 days
+        * Calculate dates based on thoughtCreatedAt timestamp (provided in user thought context)
+        * Use 24-hour time format (HH:MM): "5pm" → "17:00", "2pm" → "14:00", "9:30am" → "09:30"
+        * Include date (YYYY-MM-DD), time (HH:MM), location (if mentioned), description, and category
+        * Category selection: Work (meetings, deadlines), Personal (personal appointments), Health (doctor, dentist, therapy), Social (coffee, dinner, events), Learning (classes, workshops)
+        * **CRITICAL**: Use confidence 99-100 when user EXPLICITLY requests calendar event creation (e.g., "create a calendar event to...", "add to calendar...", "schedule...")
+        * Use confidence 90-98 for clear appointments without explicit request ("doctor tomorrow at 2pm")
+        * Use confidence 70-89 for vague timing ("meeting next week sometime")
+        * For recurring events, include recurrence in description until RRULE support is added
 
 testData:
   - thoughtText: I need to learn React hooks and build a personal portfolio website. Also feeling stressed about the upcoming deadline.
@@ -234,6 +251,34 @@ testData:
             },
             "reasoning": "Thought contains specific appointment time and reminder information",
             "relationship": "Creates time-based reminder for medical appointment with preparation notes"
+          }
+        ]
+      }
+
+  - thoughtText: Create a calendar event to call mom tomorrow at 5pm
+    thoughtType: directive
+    thoughtTags: ""
+    thoughtCreatedAt: "2025-11-20T10:00:00Z"
+    toolReference: "(Tool specs would be dynamically loaded based on enrolled tools)"
+    context: |
+      (User context would be dynamically loaded)
+
+    expected: |
+      {
+        "actions": [
+          {
+            "type": "createCalendarEvent",
+            "confidence": 99,
+            "data": {
+              "title": "Call Mom",
+              "date": "2025-11-21",
+              "time": "17:00",
+              "location": null,
+              "description": "Scheduled call with mom",
+              "category": "Personal"
+            },
+            "reasoning": "User explicitly requested calendar event creation with specific date (tomorrow) and time (5pm). This should be auto-applied immediately.",
+            "relationship": "Directly fulfills user's explicit request to create a calendar reminder for calling mom"
           }
         ]
       }


### PR DESCRIPTION
This commit significantly improves the calendar tool's ability to convert
thoughts into calendar events with high accuracy and automatic application.

## Changes Made:

### 1. Enhanced Calendar Tool Specification (shared/toolSpecs.ts)
- Added 5 detailed positive examples covering various use cases:
  * Explicit calendar event requests (99% confidence for auto-apply)
  * Natural language dates ("tomorrow at 5pm", "next Monday")
  * Appointment reminders with context
  * Social events and future appointments
- Added 3 negative examples showing when NOT to create calendar events
- Enhanced guidance for confidence scoring:
  * 99-100%: Explicit requests like "create a calendar event"
  * 90-98%: Clear appointments with specific dates/times
  * 70-89%: Events needing interpretation
- Added natural language date parsing instructions
- Included recurring event detection guidance

### 2. Improved AI Prompt (functions/prompts/process-thought.prompt.yml)
- Enhanced confidence scoring rules with explicit guidelines:
  * ALWAYS use 99-100% for explicit "create calendar event" directives
  * Clear examples of when to use high vs medium confidence
- Added comprehensive calendar event creation rules:
  * Natural language date parsing ("tomorrow", "next Monday", "in 2 weeks")
  * 24-hour time format conversion ("5pm" → "17:00")
  * Category selection guidelines (Work, Personal, Health, Social, Learning)
  * Date calculation based on thoughtCreatedAt timestamp
- Added new test example demonstrating explicit request with 99% confidence
- Clarified when to use calendar events vs tasks

### 3. UI Improvements (src/app/tools/calendar/page.tsx)
- Added Brain icon indicator for thought-created events across all views:
  * Month calendar grid with clickable event pills
  * Selected day event cards
  * Upcoming events sidebar
- Made thought-created events clickable to navigate to source thought
- Added hover effects and visual feedback for better UX
- Included "View source thought" link on event cards
- Updated modal to use ModalPortal pattern (per CLAUDE.md requirements)

## User Experience:
- Users can now simply write "create a calendar event to call mom tomorrow at 5pm"
  and it will auto-create with 99% confidence
- Clear visual distinction between AI-created and manual events
- Easy navigation back to the originating thought for context
- Improved natural language understanding for dates and times

## Technical Notes:
- All tests passing (npm test, npm run build, npx tsc)
- Functions tests passing (cd functions && npm test)
- Follows existing code patterns and CLAUDE.md guidelines
- Uses ModalPortal for proper viewport coverage per architecture docs