### PR TITLE
Collapse packing list by default on trip page

### DIFF
--- a/src/components/trip/PackingListInline.tsx
+++ b/src/components/trip/PackingListInline.tsx
@@ -85,7 +85,7 @@ export function PackingListInline({ tripId, tripName, tripStatus }: PackingListI
   const [customItemName, setCustomItemName] = useState('');
   const [customItemQuantity, setCustomItemQuantity] = useState('');
   const [isCreating, setIsCreating] = useState(false);
-  const [isExpanded, setIsExpanded] = useState(true);
+  const [isExpanded, setIsExpanded] = useState(false);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
 


### PR DESCRIPTION
Changed the initial state of isExpanded from true to false in PackingListInline component, so the packing list section is collapsed by default when viewing a trip. Users can still expand it by clicking the header.